### PR TITLE
calculating number of connections to align with v2 metrics, aligning on db / cluster

### DIFF
--- a/newrelic_v2/dashboards/newrelic-database.json
+++ b/newrelic_v2/dashboards/newrelic-database.json
@@ -221,7 +221,7 @@
                 "accountIds": [
                   3321735
                 ],
-                "query": "SELECT rate(latest(endpoint_client_connections), 5 minutes) FROM Metric FACET db TIMESERIES 5 MINUTES"
+                "query": "SELECT rate(max(endpoint_client_connections) - max(endpoint_client_disconnections), 5 minutes) FROM Metric FACET db, cluster TIMESERIES 5 MINUTES"
               }
             ],
             "platformOptions": {


### PR DESCRIPTION
The `endpoint_client_connections` metric that was previously being used for calculating the number of connections is, as it turns out, a counter, so it will never reset after clients exit, because of this it was displaying numbers that are misaligned from the reality for the current number of connections to Redis in the Connections widget in New Relic. This should be a calculation (`endpoint_client_connections - endpoint_client_disconnections`), This PR buckets them and uses the max within the bucket (max makes sense as this is a counter).

I also noticed that the widget was grouping multiple clusters together if they had the same db id (e.g. an A-A database where both clusters had the relevant crdb dbid set to 1 were being combined), hence I added the the `cluster` facet.