### PR TITLE
adding host.docker.internal to extra hosts in kickstart docker file

### DIFF
--- a/grafana_v2/dashboards/grafana_v9-11/cloud/basic/redis-cloud-active-active-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/cloud/basic/redis-cloud-active-active-dashboard_v9-11.json
@@ -133,7 +133,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_crdt_syncer_status",
+          "expr": "sum by (cluster) (database_syncer_current_status{cluster=\"$cluster\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -226,8 +226,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_crdt_syncer_ingress_bytes",
-          "legendFormat": "{{bdb_name}}",
+          "expr": "sum by (cluster) (rate(database_syncer_ingress_bytes{syncer_type=\"crdt\", cluster=\"$cluster\"}[1m]))",
+          "legendFormat": "{{db}}",
           "range": true,
           "refId": "A"
         }
@@ -385,7 +385,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_crdt_raw_dbsize{role=\"master\"}",
+          "expr": "redis_server_crdt_raw_dbsize{role=\"master\", cluster=\"$cluster\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -451,7 +451,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_crdt_peer_lag",
+          "expr": "redis_server_crdt_peer_lag{cluster=\"$cluster\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -544,8 +544,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_crdt_syncer_ingress_bytes_decompressed{crdt_replica_id=\"1\"}",
-          "legendFormat": "{{bdb_name}}",
+          "expr": "rate(database_syncer_ingress_bytes_decompressed{cluster=\"$cluster\"}[1m])",
+          "legendFormat": "{{db}}",
           "range": true,
           "refId": "A"
         }
@@ -769,7 +769,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_crdt_backlog_histlen{role=\"master\"}",
+          "expr": "redis_server_crdt_backlog_histlen{role=\"master\", cluster=\"$cluster\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -832,7 +832,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -862,8 +862,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_crdt_syncer_local_ingress_lag_time",
-          "legendFormat": "{{bdb_name}}",
+          "expr": "avg by(cluster) (database_syncer_lag_ms{syncer_type=\"crdt\", cluster=\"$cluster\"})",
+          "legendFormat": "{{db}}",
           "range": true,
           "refId": "A"
         }
@@ -980,13 +980,13 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_crdt_merge_reqs{role=\"slave\"}",
-          "legendFormat": "{{bdb_name}}",
+          "expr": "redis_server_crdt_merge_reqs{role=\"slave\", cluster=\"$cluster\"}",
+          "legendFormat": "{{db}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Ingress Sync Lag Time",
+      "title": "Merge Requests",
       "type": "timeseries"
     },
     {
@@ -1046,7 +1046,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_crdt_gc_collected{role=\"master\"}",
+          "expr": "redis_server_crdt_gc_collected{role=\"master\", cluster=\"$cluster\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -1064,7 +1064,7 @@
     "list": [
       {
         "current": {},
-        "definition": "label_values(bdb_up,cluster)",
+        "definition": "label_values(redis_up,cluster)",
         "description": "The name of the deployed cluster",
         "hide": 0,
         "includeAll": false,
@@ -1073,7 +1073,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(bdb_up,cluster)",
+          "query": "label_values(redis_up,cluster)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,

--- a/grafana_v2/dashboards/grafana_v9-11/cloud/basic/redis-cloud-database-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/cloud/basic/redis-cloud-database-dashboard_v9-11.json
@@ -179,7 +179,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "bdb_avg_read_latency{bdb=\"$bdb\",cluster=\"$cluster\"}",
+          "expr": "(sum(irate(endpoint_read_requests_latency_histogram_sum{db=\"$db\"}[1m]))/sum(irate(endpoint_read_requests{db=\"$db\"}[1m])))/1000000",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Read",
@@ -193,7 +193,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "bdb_avg_write_latency{bdb=\"$bdb\",cluster=\"$cluster\"}",
+          "expr": "(sum(irate(endpoint_write_requests_latency_histogram_sum{db=\"$db\"}[1m]))/sum(irate(endpoint_write_requests{db=\"$db\"}[1m])))/1000000",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Write",
@@ -265,7 +265,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_used_memory{cluster=\"$cluster\", bdb=\"$bdb\"}/bdb_memory_limit{cluster=\"$cluster\",bdb=\"$bdb\"}",
+          "expr": "sum by (db,cluster) (redis_server_used_memory{db=\"$db\", cluster=\"$cluster\"}) / sum by (db,cluster) (redis_server_maxmemory{db=\"$db\", cluster=\"$cluster\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -334,7 +334,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_total_req{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by (db, cluster) (irate(endpoint_read_requests{db=\"$db\", cluster=\"$cluster\"}[1m]) + irate(endpoint_write_requests{db=\"$db\", cluster=\"$cluster\"}[1m]) + irate(endpoint_other_requests{db=\"$db\", cluster=\"$cluster\"}[1m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -428,7 +428,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_read_req{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by (db, cluster) (irate(endpoint_read_requests{db=\"$db\", cluster=\"$cluster\"}[1m]))",
           "hide": false,
           "legendFormat": "read",
           "range": true,
@@ -440,7 +440,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_write_req{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by (db, cluster) (irate(endpoint_write_requests{db=\"$db\", cluster=\"$cluster\"}[1m]))",
           "hide": false,
           "legendFormat": "write",
           "range": true,
@@ -452,7 +452,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_other_req{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by(db, cluster) (irate(endpoint_other_requests{db=\"$db\", cluster=\"$cluster\"}[1m]))",
           "legendFormat": "other",
           "range": true,
           "refId": "A"
@@ -522,7 +522,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "scalar(bdb_no_of_keys{bdb=\"$bdb\", cluster=\"$cluster\"})",
+          "expr": "scalar(sum by (db, cluster) (redis_server_db_keys{role=\"master\", db=\"$db\", cluster=\"$cluster\"}))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -591,7 +591,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_expired_objects{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by (db, cluster) (irate(redis_server_expired_keys{role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
           "legendFormat": "Expired Keys",
           "range": true,
           "refId": "A"
@@ -658,7 +658,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "scalar(bdb_conns{bdb=\"$bdb\", cluster=\"$cluster\"})",
+          "expr": "scalar(sum by (db, cluster) (endpoint_client_connections{cluster=\"$cluster\", db=\"$db\"} - endpoint_client_disconnections{cluster=\"$cluster\", db=\"$db\"}))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -730,7 +730,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_read_misses + bdb_write_misses{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "(sum by (db, cluster) (irate(redis_server_keyspace_read_misses{role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by (db, cluster) (irate(redis_server_keyspace_write_misses{role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m])))",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
@@ -800,7 +800,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_main_thread_cpu_system{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by(db, cluster) (irate(namedprocess_namegroup_thread_cpu_seconds_total{mode=\"system\", threadname=~\"redis-server.*\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -869,7 +869,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_main_thread_cpu_user{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by(db, cluster) (irate(namedprocess_namegroup_thread_cpu_seconds_total{mode=\"user\", threadname=~\"redis-server.*\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -898,7 +898,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(node_up,cluster)",
+          "query": "label_values(endpoint_client_connections,cluster)",
           "refId": "Redis-Enterprise-cluster-Variable-Query"
         },
         "refresh": 1,
@@ -910,73 +910,20 @@
       },
       {
         "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "bdb_conns{cluster=\"$cluster\"}",
-        "hide": 0,
-        "includeAll": false,
-        "label": "database",
-        "multi": false,
-        "name": "bdb",
+        "definition": "label_values(endpoint_client_connections{cluster=\"$cluster\"},db)",
+        "description": "endpoint_client_connections{cluster=\"$cluster\"}",
+        "label": "db",
+        "name": "db",
         "options": [],
         "query": {
-          "query": "bdb_conns{cluster=\"$cluster\"}",
-          "refId": "StandardVariableQuery"
+          "qryType": 1,
+          "query": "label_values(endpoint_client_connections{cluster=\"$cluster\"},db)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "/bdb_name=\"(?<text>[^\"]+)|bdb=\"(?<value>[^\"]+)/g",
-        "skipUrlSync": false,
+        "regex": "",
         "sort": 1,
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "status",
-        "options": [],
-        "query": {
-          "query": "label_values(bdb_status{bdb=\"$bdb\", cluster=\"$cluster\"}, status)",
-          "refId": "Redis-Enterprise-status-Variable-Query"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "newStatus",
-        "options": [],
-        "query": {
-          "query": "label_values(bdb_up{bdb=\"$bdb\", cluster=\"$cluster\"}, status)",
-          "refId": "Redis-Enterprise-newStatus-Variable-Query"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "auto": true,

--- a/grafana_v2/dashboards/grafana_v9-11/cloud/basic/redis-cloud-proxy-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/cloud/basic/redis-cloud-proxy-dashboard_v9-11.json
@@ -198,7 +198,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "dmcproxy_process_cpu_usage_percent{cluster=\"$cluster\", node=\"$node\"}",
+          "expr": "avg by(node)(irate(dmcproxy_process_cpu_user_seconds_total{cluster=\"$cluster\", node=\"$node\"}[1m])) * 100",
           "hide": true,
           "instant": false,
           "legendFormat": "__auto",
@@ -214,17 +214,6 @@
           "hide": false,
           "refId": "C",
           "type": "math"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "",
-          "hide": false,
-          "instant": false,
-          "range": true,
-          "refId": "D"
         }
       ],
       "title": "Proxy CPU Usage (avg)",
@@ -359,7 +348,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "dmcproxy_process_open_fds{cluster=\"$cluster\",node=\"$node\"}",
+          "expr": "sum by (node)(namedprocess_namegroup_open_filedesc{cluster=\"$cluster\",node=\"$node\"})",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -643,7 +632,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(cluster)",
+        "definition": "label_values(namedprocess_namegroup_cpu_seconds_total, cluster)",
         "hide": 0,
         "includeAll": false,
         "label": "",
@@ -652,7 +641,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(cluster)",
+          "query": "label_values(namedprocess_namegroup_cpu_seconds_total, cluster)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -668,7 +657,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(node_up,node)",
+        "definition": "label_values(namedprocess_namegroup_cpu_seconds_total{cluster=\"cluster\"},node)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
@@ -676,7 +665,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(node_up,node)",
+          "query": "label_values(namedprocess_namegroup_cpu_seconds_total{cluster=\"cluster\"},node)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,

--- a/grafana_v2/dashboards/grafana_v9-11/cloud/basic/redis-cloud-proxy-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/cloud/basic/redis-cloud-proxy-dashboard_v9-11.json
@@ -657,7 +657,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(namedprocess_namegroup_cpu_seconds_total{cluster=\"cluster\"},node)",
+        "definition": "label_values(namedprocess_namegroup_cpu_seconds_total{cluster=\"$cluster\"},node)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
@@ -665,7 +665,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(namedprocess_namegroup_cpu_seconds_total{cluster=\"cluster\"},node)",
+          "query": "label_values(namedprocess_namegroup_cpu_seconds_total{cluster=\"$cluster\"},node)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,

--- a/grafana_v2/dashboards/grafana_v9-11/cloud/basic/redis-cloud-subscription-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/cloud/basic/redis-cloud-subscription-dashboard_v9-11.json
@@ -135,7 +135,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "count(bdb_up{cluster=\"$cluster\"})",
+          "expr": "count by (db)(endpoint_client_connections{cluster=\"$cluster\"})",
           "legendFormat": "count",
           "range": true,
           "refId": "A"
@@ -201,7 +201,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "sum(bdb_used_memory{cluster=\"$cluster\"})",
+          "expr": "sum(redis_server_used_memory{cluster=\"$cluster\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -267,7 +267,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "sum(bdb_total_req{cluster=\"$cluster\"})",
+          "expr": "sum(irate(endpoint_read_requests{cluster=\"$cluster\"}[1m])) + sum(irate(endpoint_write_requests{cluster=\"$cluster\"}[1m])) + sum(irate(endpoint_other_requests{cluster=\"$cluster\"}[1m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -290,7 +290,7 @@
       },
       "id": 59,
       "panels": [],
-      "repeat": "bdb",
+      "repeat": "db",
       "repeatDirection": "h",
       "targets": [
         {
@@ -301,7 +301,7 @@
           "refId": "A"
         }
       ],
-      "title": "Database: $bdb",
+      "title": "Database: $db",
       "type": "row"
     },
     {
@@ -377,7 +377,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(bdb_used_memory{cluster=\"$cluster\",bdb=\"$bdb\"}/bdb_memory_limit{cluster=\"$cluster\",bdb=\"$bdb\"})",
+          "expr": "avg by(db)((redis_server_used_memory{cluster=\"$cluster\",db=\"$db\"}/redis_server_maxmemory{cluster=\"$cluster\",db=\"$db\"}))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -447,7 +447,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_avg_latency{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "(sum by (cluster, db)(irate(endpoint_read_requests_latency_histogram_sum{cluster=\"$cluster\", db=\"$db\"}[1m]))  + sum by(cluster, db) (irate(endpoint_write_requests_latency_histogram_sum{cluster=\"$cluster\", db=\"$db\"}[1m]) ) + sum by (cluster, db) (irate(endpoint_other_requests_latency_histogram_sum{cluster=\"$cluster\", db=\"$db\"}[1m]))) / ((sum by (cluster, db) (irate(endpoint_read_requests{cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by(cluster, db)(irate(endpoint_write_requests{cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by(cluster, db)(irate(endpoint_other_requests{cluster=\"$cluster\", db=\"$db\"}[1m])))) / 1000",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -512,7 +512,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "bdb_total_req{cluster=\"$cluster\",bdb=\"$bdb\"}",
+          "expr": "sum(irate(endpoint_read_requests{cluster=\"$cluster\", db=\"$db\"}[1m])) + sum(irate(endpoint_write_requests{cluster=\"$cluster\", db=\"$db\"}[1m])) + sum(irate(endpoint_other_requests{cluster=\"$cluster\", db=\"$db\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -580,7 +580,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "bdb_expired_objects{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by (db)(irate(redis_server_expired_keys{role=\"master\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -651,7 +651,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "scalar(bdb_no_of_keys{bdb=\"$bdb\", cluster=\"$cluster\"})",
+          "expr": "scalar(sum by(db)(redis_server_db_keys{db=\"$db\", cluster=\"$cluster\", role=\"master\"}))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -719,7 +719,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "scalar(bdb_conns{bdb=\"$bdb\", cluster=\"$cluster\"})",
+          "expr": "scalar(sum by (db)(endpoint_client_connections{db=\"$db\", cluster=\"$cluster\"} - endpoint_client_disconnections{cluster=\"$cluster\", db=\"$db\"}))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -764,147 +764,20 @@
       },
       {
         "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(bdb_status{bdb=\"$bdb\", cluster=\"$cluster\"}, status)",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "status",
+        "definition": "label_values(endpoint_client_connections{cluster=\"$cluster\"},db)",
+        "description": "endpoint_client_connections{cluster=\"$cluster\"}",
+        "label": "db",
+        "name": "db",
         "options": [],
         "query": {
-          "query": "label_values(bdb_status{bdb=\"$bdb\", cluster=\"$cluster\"}, status)",
-          "refId": "StandardVariableQuery"
+          "qryType": 1,
+          "query": "label_values(endpoint_client_connections{cluster=\"$cluster\"},db)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "newStatus",
-        "options": [],
-        "query": {
-          "query": "label_values(bdb_up{bdb=\"$bdb\", cluster=\"$cluster\"}, status)",
-          "refId": "Redis-Enterprise-newStatus-Variable-Query"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": ".*",
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "bdb_up{cluster=\"$cluster\"}",
-        "hide": 1,
-        "includeAll": true,
-        "multi": false,
-        "name": "bdb",
-        "options": [],
-        "query": {
-          "query": "bdb_up{cluster=\"$cluster\"}",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "/bdb=\"(?<value>[^\"]+)|bdb_name=\"(?<text>[^\"]+)/g",
-        "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "type": "query"
-      },
-      {
-        "auto": true,
-        "auto_count": 100,
-        "auto_min": "1m",
-        "current": {
-          "selected": false,
-          "text": "auto",
-          "value": "$__auto_interval_aggregation"
-        },
-        "hide": 0,
-        "label": "aggregation interval",
-        "name": "aggregation",
-        "options": [
-          {
-            "selected": true,
-            "text": "auto",
-            "value": "$__auto_interval_aggregation"
-          },
-          {
-            "selected": false,
-            "text": "1m",
-            "value": "1m"
-          },
-          {
-            "selected": false,
-            "text": "10m",
-            "value": "10m"
-          },
-          {
-            "selected": false,
-            "text": "30m",
-            "value": "30m"
-          },
-          {
-            "selected": false,
-            "text": "1h",
-            "value": "1h"
-          },
-          {
-            "selected": false,
-            "text": "6h",
-            "value": "6h"
-          },
-          {
-            "selected": false,
-            "text": "12h",
-            "value": "12h"
-          },
-          {
-            "selected": false,
-            "text": "1d",
-            "value": "1d"
-          },
-          {
-            "selected": false,
-            "text": "7d",
-            "value": "7d"
-          },
-          {
-            "selected": false,
-            "text": "14d",
-            "value": "14d"
-          },
-          {
-            "selected": false,
-            "text": "30d",
-            "value": "30d"
-          }
-        ],
-        "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
-        "queryValue": "",
-        "refresh": 2,
-        "skipUrlSync": false,
-        "type": "interval"
       }
     ]
   },

--- a/grafana_v2/dashboards/grafana_v9-11/cloud/basic/redis-cloud-subscription-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/cloud/basic/redis-cloud-subscription-dashboard_v9-11.json
@@ -413,7 +413,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-active-active-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-active-active-dashboard_v9-11.json
@@ -418,7 +418,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -832,7 +832,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-active-active-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-active-active-dashboard_v9-11.json
@@ -320,7 +320,7 @@
           },
           "editorMode": "builder",
           "expr": "bdb_crdt_syncer_egress_bytes",
-          "legendFormat": "{{bdb_name}}",
+          "legendFormat": "{{cluster}}",
           "range": true,
           "refId": "A"
         }
@@ -385,7 +385,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_crdt_raw_dbsize{role=\"master\"}",
+          "expr": "redis_server_crdt_raw_dbsize{role=\"master\", cluster=\"$cluster\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -451,7 +451,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_crdt_peer_lag",
+          "expr": "redis_server_crdt_peer_lag{cluster=\"$cluster\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -638,7 +638,7 @@
           },
           "editorMode": "builder",
           "expr": "bdb_crdt_syncer_egress_bytes_decompressed",
-          "legendFormat": "{{bdb_name}}",
+          "legendFormat": "{{cluster}}",
           "range": true,
           "refId": "A"
         }
@@ -769,7 +769,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_crdt_backlog_histlen{role=\"master\"}",
+          "expr": "redis_server_crdt_backlog_histlen{role=\"master\", cluster=\"$cluster\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -980,8 +980,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_crdt_merge_reqs{role=\"slave\"}",
-          "legendFormat": "{{bdb_name}}",
+          "expr": "redis_server_crdt_merge_reqs{role=\"slave\", cluster=\"$cluster\"}",
+          "legendFormat": "{{cluster}}",
           "range": true,
           "refId": "A"
         }
@@ -1046,7 +1046,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_crdt_gc_collected{role=\"master\"}",
+          "expr": "redis_server_crdt_gc_collected{role=\"master\", cluster=\"$cluster\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-active-active-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-active-active-dashboard_v9-11.json
@@ -133,7 +133,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_crdt_syncer_status",
+          "expr": "database_syncer_current_status{cluster=\"$cluster\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -226,8 +226,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_crdt_syncer_ingress_bytes",
-          "legendFormat": "{{bdb_name}}",
+          "expr": "sum by (cluster) (rate(database_syncer_ingress_bytes{syncer_type=\"crdt\", cluster=\"$cluster\"}[1m]))",
+          "legendFormat": "{{cluster}}",
           "range": true,
           "refId": "A"
         }
@@ -544,8 +544,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_crdt_syncer_ingress_bytes_decompressed{crdt_replica_id=\"1\"}",
-          "legendFormat": "{{bdb_name}}",
+          "expr": "rate(database_syncer_ingress_bytes_decompressed{cluster=\"$cluster\"}[1m])",
+          "legendFormat": "{{cluster}}",
           "range": true,
           "refId": "A"
         }
@@ -862,8 +862,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_crdt_syncer_local_ingress_lag_time",
-          "legendFormat": "{{bdb_name}}",
+          "expr": "avg by(cluster) (database_syncer_lag_ms{syncer_type=\"crdt\", cluster=\"$cluster\"})",
+          "legendFormat": "{{cluster}}",
           "range": true,
           "refId": "A"
         }
@@ -925,7 +925,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": [
           {
@@ -1064,7 +1064,7 @@
     "list": [
       {
         "current": {},
-        "definition": "label_values(bdb_up,cluster)",
+        "definition": "label_values(redis_up,cluster)",
         "description": "The name of the deployed cluster",
         "hide": 0,
         "includeAll": false,
@@ -1073,7 +1073,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(bdb_up,cluster)",
+          "query": "label_values(redis_up,cluster)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-active-active-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-active-active-dashboard_v9-11.json
@@ -986,7 +986,7 @@
           "refId": "A"
         }
       ],
-      "title": "Ingress Sync Lag Time",
+      "title": "Merge Requests",
       "type": "timeseries"
     },
     {

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-active-active-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-active-active-dashboard_v9-11.json
@@ -133,7 +133,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "database_syncer_current_status{cluster=\"$cluster\"}",
+          "expr": "sum by (cluster) (database_syncer_current_status{cluster=\"$cluster\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json
@@ -377,7 +377,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by(cluster, db)(redis_server_used_memory{cluster=\"$cluster\", db=\"$db\"}) / sum by(cluster)(redis_server_maxmemory{cluster=\"$cluster\", db=\"$db\"})",
+          "expr": "sum by(cluster, db)(redis_server_used_memory{cluster=\"$cluster\", db=\"$db\"}) / sum by(cluster, db)(redis_server_maxmemory{cluster=\"$cluster\", db=\"$db\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -447,7 +447,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "(sum by (cluster, db)(irate(endpoint_read_requests_latency_histogram_sum{cluster=\"$cluster\", db=\"$db\"}[1m]))  + sum by(cluster) (irate(endpoint_write_requests_latency_histogram_sum{cluster=\"$cluster\", db=\"$db\"}[1m]) ) + sum by (cluster) (irate(endpoint_other_requests_latency_histogram_sum{cluster=\"$cluster\", db=\"$db\"}[1m]))) / ((sum by (cluster) (irate(endpoint_read_requests{cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by(cluster)(irate(endpoint_write_requests{cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by(cluster)(irate(endpoint_other_requests{cluster=\"$cluster\", db=\"$db\"}[1m])))) / 1000",
+          "expr": "(sum by (cluster, db)(irate(endpoint_read_requests_latency_histogram_sum{cluster=\"$cluster\", db=\"$db\"}[1m]))  + sum by(cluster, db) (irate(endpoint_write_requests_latency_histogram_sum{cluster=\"$cluster\", db=\"$db\"}[1m]) ) + sum by (cluster, db) (irate(endpoint_other_requests_latency_histogram_sum{cluster=\"$cluster\", db=\"$db\"}[1m]))) / ((sum by (cluster, db) (irate(endpoint_read_requests{cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by(cluster, db)(irate(endpoint_write_requests{cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by(cluster, db)(irate(endpoint_other_requests{cluster=\"$cluster\", db=\"$db\"}[1m])))) / 1000",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json
@@ -135,7 +135,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "count(bdb_up{cluster=\"$cluster\"})",
+          "expr": "count(redis_up{cluster=\"$cluster\"})",
           "legendFormat": "count",
           "range": true,
           "refId": "A"
@@ -201,7 +201,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "sum(bdb_used_memory{cluster=\"$cluster\"})",
+          "expr": "sum(redis_server_used_memory{cluster=\"$cluster\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -267,7 +267,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "sum(bdb_total_req{cluster=\"$cluster\"})",
+          "expr": "(sum by (cluster) (irate (endpoint_read_requests{cluster=\"$cluster\"}[1m]))) + (sum by (cluster) (irate(endpoint_write_requests{cluster=\"$cluster\"}[1m]))) + (sum by(cluster) (irate (endpoint_other_requests{cluster=\"$cluster\"}[1m])))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -301,7 +301,7 @@
           "refId": "A"
         }
       ],
-      "title": "$bdb",
+      "title": "$db",
       "type": "row"
     },
     {
@@ -377,7 +377,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(bdb_used_memory{cluster=\"$cluster\",bdb=\"$bdb\"}/bdb_memory_limit{cluster=\"$cluster\",bdb=\"$bdb\"})",
+          "expr": "sum by(cluster, db)(redis_server_used_memory{cluster=\"$cluster\", db=\"$db\"}) / sum by(cluster)(redis_server_maxmemory{cluster=\"$cluster\", db=\"$db\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -413,7 +413,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -447,7 +447,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_avg_latency{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "(sum by (cluster, db)(irate(endpoint_read_requests_latency_histogram_sum{cluster=\"$cluster\", db=\"$db\"}[1m]))  + sum by(cluster) (irate(endpoint_write_requests_latency_histogram_sum{cluster=\"$cluster\", db=\"$db\"}[1m]) ) + sum by (cluster) (irate(endpoint_other_requests_latency_histogram_sum{cluster=\"$cluster\", db=\"$db\"}[1m]))) / ((sum by (cluster) (irate(endpoint_read_requests{cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by(cluster)(irate(endpoint_write_requests{cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by(cluster)(irate(endpoint_other_requests{cluster=\"$cluster\", db=\"$db\"}[1m])))) / 1000",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -512,7 +512,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "bdb_total_req{cluster=\"$cluster\",bdb=\"$bdb\"}",
+          "expr": "sum by(cluster, db)(irate(endpoint_read_requests{cluster=\"$cluster\", db=\"$db\"}[1m]) + irate(endpoint_write_requests{cluster=\"$cluster\", db=\"$db\"}[1m]) + irate(endpoint_other_requests{cluster=\"$cluster\", db=\"$db\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -580,7 +580,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "bdb_expired_objects{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by(cluster) (irate(redis_server_expired_keys{role=\"master\", cluster=\"$cluster\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -651,7 +651,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "scalar(bdb_no_of_keys{bdb=\"$bdb\", cluster=\"$cluster\"})",
+          "expr": "scalar(sum by(cluster, db)(redis_server_db_keys{role=\"master\", cluster=\"$cluster\", db=\"$db\"}))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -719,7 +719,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "scalar(bdb_conns{bdb=\"$bdb\", cluster=\"$cluster\"})",
+          "expr": "scalar(sum by(cluster, db)(endpoint_client_connections{cluster=\"$cluster\", db=\"$db\"} - endpoint_client_disconnections{cluster=\"$cluster\", db=\"$db\"}))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -759,52 +759,6 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(bdb_status{bdb=\"$bdb\", cluster=\"$cluster\"}, status)",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "status",
-        "options": [],
-        "query": {
-          "query": "label_values(bdb_status{bdb=\"$bdb\", cluster=\"$cluster\"}, status)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "newStatus",
-        "options": [],
-        "query": {
-          "query": "label_values(bdb_up{bdb=\"$bdb\", cluster=\"$cluster\"}, status)",
-          "refId": "Redis-Enterprise-newStatus-Variable-Query"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query",
         "useTags": false
       },
@@ -884,26 +838,20 @@
         "type": "interval"
       },
       {
-        "allValue": ".*",
         "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "bdb_up{cluster=\"$cluster\"}",
-        "hide": 2,
-        "includeAll": true,
-        "multi": false,
-        "name": "bdb",
+        "definition": "label_values(endpoint_client_connections{cluster=\"$cluster\"},db)",
+        "description": "endpoint_client_connections{cluster=\"$cluster\"}",
+        "label": "db",
+        "name": "db",
         "options": [],
         "query": {
-          "query": "bdb_up{cluster=\"$cluster\"}",
-          "refId": "StandardVariableQuery"
+          "qryType": 1,
+          "query": "label_values(endpoint_client_connections{cluster=\"$cluster\"},db)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "/bdb=\"(?<value>[^\"]+)|bdb_name=\"(?<text>[^\"]+)/g",
-        "skipUrlSync": false,
-        "sort": 0,
+        "regex": "",
+        "sort": 1,
         "type": "query"
       }
     ]

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json
@@ -841,6 +841,7 @@
         "current": {},
         "allValue":".*",
         "includeAll": true,
+        "hide": 2,
         "definition": "label_values(endpoint_client_connections{cluster=\"$cluster\"},db)",
         "description": "endpoint_client_connections{cluster=\"$cluster\"}",
         "label": "db",
@@ -853,7 +854,7 @@
         },
         "refresh": 1,
         "regex": "",
-        "sort": 1,
+        "sort": 0,
         "type": "query"
       }
     ]

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json
@@ -839,6 +839,8 @@
       },
       {
         "current": {},
+        "allValue":".*",
+        "includeAll": true,
         "definition": "label_values(endpoint_client_connections{cluster=\"$cluster\"},db)",
         "description": "endpoint_client_connections{cluster=\"$cluster\"}",
         "label": "db",

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json
@@ -290,7 +290,7 @@
       },
       "id": 59,
       "panels": [],
-      "repeat": "bdb",
+      "repeat": "db",
       "repeatDirection": "h",
       "targets": [
         {

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-database-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-database-dashboard_v9-11.json
@@ -889,7 +889,7 @@
         "definition": "label_values(endpoint_client_connections{cluster=\"$cluster\"},db)",
         "description": "endpoint_client_connections{cluster=\"$cluster\"}",
         "label": "db",
-        "name": "database",
+        "name": "db",
         "options": [],
         "query": {
           "qryType": 1,

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-database-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-database-dashboard_v9-11.json
@@ -178,7 +178,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "bdb_avg_read_latency{bdb=\"$bdb\",cluster=\"$cluster\"}",
+          "expr": "(sum(irate(endpoint_read_requests_latency_histogram_sum{db=\"$db\"}[1m]))/sum(irate(endpoint_read_requests{db=\"$db\"}[1m])))/1000000",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Read",
@@ -192,7 +192,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "bdb_avg_write_latency{bdb=\"$bdb\",cluster=\"$cluster\"}",
+          "expr": "(sum(irate(endpoint_write_requests_latency_histogram_sum{db=\"$db\"}[1m]))/sum(irate(endpoint_write_requests{db=\"$db\"}[1m])))/1000000",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Write",
@@ -261,7 +261,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_used_memory{cluster=\"$cluster\", bdb=\"$bdb\"}/bdb_memory_limit{cluster=\"$cluster\",bdb=\"$bdb\"}",
+          "expr":"sum by (db,cluster) (redis_server_used_memory{db=\"$db\", cluster=\"$cluster\"}) / sum by (db,cluster) (redis_server_maxmemory{db=\"$db\", cluster=\"$cluster\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -327,7 +327,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_total_req{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by (db, cluster) (irate(endpoint_read_requests{db=\"$db\", cluster=\"$cluster\"}[1m]) + irate(endpoint_write_requests{db=\"$db\", cluster=\"$cluster\"}[1m]) + irate(endpoint_other_requests{db=\"db\", cluster=\"$cluster\"}[1m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -419,7 +419,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_read_req{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by (db, cluster) (irate(endpoint_read_requests{db=\"$db\", cluster=\"$cluster\"}[1m]))",
           "hide": false,
           "legendFormat": "read",
           "range": true,
@@ -431,7 +431,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_write_req{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by (db, cluster) (irate(endpoint_write_requests{db=\"$db\", cluster=\"$cluster\"}[1m]))",
           "hide": false,
           "legendFormat": "write",
           "range": true,
@@ -443,7 +443,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_other_req{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by(db, cluster) (irate(endpoint_other_requests{db=\"$db\", cluster=\"$cluster\"}[1m]))",
           "legendFormat": "other",
           "range": true,
           "refId": "A"
@@ -511,7 +511,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "scalar(bdb_no_of_keys{bdb=\"$bdb\", cluster=\"$cluster\"})",
+          "expr": "scalar(sum by (db, cluster) (redis_server_db_keys{role=\"master\", db=\"$db\", cluster=\"$cluster\"}))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -577,7 +577,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_expired_objects{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by (db, cluster) (irate(redis_server_expired_keys{role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
           "legendFormat": "Expired Keys",
           "range": true,
           "refId": "A"
@@ -642,7 +642,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "scalar(bdb_conns{bdb=\"$bdb\", cluster=\"$cluster\"})",
+          "expr": "scalar(sum by (db, cluster) (endpoint_client_connections{cluster=\"$cluster\", db=\"$db\"} - endpoint_client_disconnections{cluster=\"$cluster\", db=\"$db\"}))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -711,7 +711,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_read_misses + bdb_write_misses{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "(sum by (db, cluster) (irate(redis_server_keyspace_read_misses{role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by (db, cluster) (irate(redis_server_keyspace_write_misses{role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m])))",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
@@ -778,7 +778,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_main_thread_cpu_system{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by(db, cluster) (irate(namedprocess_namegroup_thread_cpu_seconds_total{mode=\"system\", threadname=~\"redis-server.*\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -844,7 +844,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "bdb_main_thread_cpu_user{cluster=\"$cluster\", bdb=\"$bdb\"}",
+          "expr": "sum by(db, cluster) (irate(namedprocess_namegroup_thread_cpu_seconds_total{mode=\"user\", threadname=~\"redis-server.*\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -886,73 +886,20 @@
       },
       {
         "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "bdb_conns{cluster=\"$cluster\"}",
-        "hide": 0,
-        "includeAll": false,
-        "label": "database",
-        "multi": false,
-        "name": "bdb",
+        "definition": "label_values(endpoint_client_connections{cluster=\"$cluster\"},db)",
+        "description": "endpoint_client_connections{cluster=\"$cluster\"}",
+        "label": "db",
+        "name": "database",
         "options": [],
         "query": {
-          "query": "bdb_conns{cluster=\"$cluster\"}",
-          "refId": "StandardVariableQuery"
+          "qryType": 1,
+          "query": "label_values(endpoint_client_connections{cluster=\"$cluster\"},db)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "/bdb_name=\"(?<text>[^\"]+)|bdb=\"(?<value>[^\"]+)/g",
-        "skipUrlSync": false,
+        "regex": "",
         "sort": 1,
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "status",
-        "options": [],
-        "query": {
-          "query": "label_values(bdb_status{bdb=\"$bdb\", cluster=\"$cluster\"}, status)",
-          "refId": "Redis-Enterprise-status-Variable-Query"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "newStatus",
-        "options": [],
-        "query": {
-          "query": "label_values(bdb_up{bdb=\"$bdb\", cluster=\"$cluster\"}, status)",
-          "refId": "Redis-Enterprise-newStatus-Variable-Query"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "auto": true,

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-database-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-database-dashboard_v9-11.json
@@ -327,7 +327,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "sum by (db, cluster) (irate(endpoint_read_requests{db=\"$db\", cluster=\"$cluster\"}[1m]) + irate(endpoint_write_requests{db=\"$db\", cluster=\"$cluster\"}[1m]) + irate(endpoint_other_requests{db=\"db\", cluster=\"$cluster\"}[1m]))",
+          "expr": "sum by (db, cluster) (irate(endpoint_read_requests{db=\"$db\", cluster=\"$cluster\"}[1m]) + irate(endpoint_write_requests{db=\"$db\", cluster=\"$cluster\"}[1m]) + irate(endpoint_other_requests{db=\"$db\", cluster=\"$cluster\"}[1m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-node-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-node-dashboard_v9-11.json
@@ -181,7 +181,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count(count(redis_used_memory{cluster=\"$cluster\", node=\"$node\"}) by (bdb))",
+          "expr": "count(count(redis_server_used_memory{cluster=\"$cluster\", node=\"$node\"}) by (bdb))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -263,7 +263,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count(redis_used_memory{cluster=\"$cluster\", node=\"$node\", role=\"master\"})",
+          "expr": "count(redis_server_used_memory{cluster=\"$cluster\", node=\"$node\", role=\"master\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -345,7 +345,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count(redis_used_memory{cluster=\"$cluster\", node=\"$node\", role=\"slave\"})",
+          "expr": "count(redis_server_used_memory{cluster=\"$cluster\", node=\"$node\", role=\"slave\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -433,7 +433,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "node_cpu_system{node=\"$node\",cluster=\"$cluster\"} + node_cpu_user{node=\"$node\",cluster=\"$cluster\"}",
+          "expr": "(avg by(node) (irate(node_cpu_seconds_total{mode=\"system\", cluster=\"$cluster\", node=\"$node\"}[1m]))) + (avg by(node) (irate(node_cpu_seconds_total{mode=\"user\", cluster=\"$cluster\", node=\"$node\"}[1m])))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -514,7 +514,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "node_available_memory{cluster=\"$cluster\",node=\"$node\"}",
+          "expr": "node_available_memory_bytes{cluster=\"$cluster\",node=\"$node\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -713,7 +713,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": " node_cpu_user{cluster=\"$cluster\", node=\"$node\"} + node_cpu_system{cluster=\"$cluster\", node=\"$node\"}",
+          "expr": "(avg by(node) (irate(node_cpu_seconds_total{mode=\"system\", cluster=\"$cluster\", node=\"$node\"}[1m]))) + (avg by(node) (irate(node_cpu_seconds_total{mode=\"user\", cluster=\"$cluster\", node=\"$node\"}[1m])))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -726,7 +726,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "1- node_cpu_idle{cluster=\"$cluster\", node=\"$node\"} - node_cpu_system{cluster=\"$cluster\", node=\"$node\"} - node_cpu_user{cluster=\"$cluster\", node=\"$node\"} unless node_cpu_nice{cluster=\"$cluster\", node=\"$node\"}",
+          "expr": "1- (avg by(node)(irate(node_cpu_seconds_total{mode=\"idle\",cluster=\"$cluster\", node=\"$node\"}[1m]))) - (avg by(node)(irate(node_cpu_seconds_total{mode=\"system\",cluster=\"$cluster\", node=\"$node\"}[1m]))) - (avg by(node)(irate(node_cpu_seconds_total{mode=\"user\",cluster=\"$cluster\", node=\"$node\"}[1m]))) unless (avg by(node)(irate(node_cpu_seconds_total{mode=\"nice\",cluster=\"$cluster\", node=\"$node\"}[1m])))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -739,7 +739,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "node_cpu_steal{cluster=\"$cluster\", node=\"$node\"}",
+          "expr": "(avg by(node)(irate(node_cpu_seconds_total{mode=\"steal\",cluster=\"$cluster\", node=\"$node\"}[1m])))",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 2,
@@ -752,7 +752,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "node_cpu_nice{cluster=\"$cluster\", node=\"$node\"}",
+          "expr": "(avg by(node)(irate(node_cpu_seconds_total{mode=\"nice\",cluster=\"$cluster\", node=\"$node\"}[1m])))",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 2,
@@ -765,7 +765,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "node_cpu_irqs{cluster=\"$cluster\", node=\"$node\"}",
+          "expr": "(avg by(node)(irate(node_cpu_seconds_total{mode=\"irq\",cluster=\"$cluster\", node=\"$node\"}[1m])))",
           "format": "time_series",
           "hide": true,
           "interval": "",
@@ -779,7 +779,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "dmcproxy_process_cpu_usage_percent{cluster=\"$cluster\", node=\"$node\"}/100",
+          "expr": "avg by(node)(irate(dmcproxy_process_cpu_user_seconds_total{cluster=\"$cluster\", node=\"$node\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -792,7 +792,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": " node_cpu_iowait{cluster=\"$cluster\", node=\"$node\"}",
+          "expr": "avg by(node)(irate(node_cpu_seconds_total{mode=\"iowait\", cluster=\"$cluster\", node=\"$node\"}[1m]))",
           "format": "time_series",
           "hide": true,
           "interval": "",
@@ -806,7 +806,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(redis_process_cpu_usage_percent{cluster=\"$cluster\", node=\"$node\"}/100)",
+          "expr": "avg by(node)(irate(node_cpu_seconds_total{mode=~\"system|user\", cluster=\"$cluster\", node=\"$node\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -970,7 +970,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "node_ingress_bytes{cluster=\"$cluster\", node=\"$node\"}",
+          "expr": "sum by(node)(irate(node_network_receive_bytes_total{cluster=\"$cluster\", node=\"$node\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -984,7 +984,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "node_egress_bytes{cluster=\"$cluster\", node=\"$node\"}",
+          "expr": "sum by(node)(irate(node_network_transmit_bytes_total{cluster=\"$cluster\", node=\"$node\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1164,7 +1164,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "avg(redis_allocator_active{node=\"$node\",cluster=\"$cluster\"} / redis_allocator_allocated{node=\"$node\",cluster=\"$cluster\"}) - 1",
+          "expr": "avg(redis_server_allocator_active{node=\"$node\",cluster=\"$cluster\"} / redis_server_allocator_allocated{node=\"$node\",cluster=\"$cluster\"}) - 1",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1179,7 +1179,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "avg(redis_allocator_resident{node=\"$node\",cluster=\"$cluster\"} / redis_allocator_active{node=\"$node\",cluster=\"$cluster\"}) - 1",
+          "expr": "avg(redis_server_allocator_resident{node=\"$node\",cluster=\"$cluster\"} / redis_server_allocator_active{node=\"$node\",cluster=\"$cluster\"}) - 1",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1194,7 +1194,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(redis_allocator_active{node=\"$node\",cluster=\"$cluster\"} - redis_allocator_allocated{node=\"$node\",cluster=\"$cluster\"})",
+          "expr": "sum(redis_server_allocator_active{node=\"$node\",cluster=\"$cluster\"} - redis_server_allocator_allocated{node=\"$node\",cluster=\"$cluster\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1209,7 +1209,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(redis_allocator_resident{node=\"$node\",cluster=\"$cluster\"} - redis_allocator_active{node=\"$node\",cluster=\"$cluster\"})",
+          "expr": "sum(redis_server_allocator_resident{node=\"$node\",cluster=\"$cluster\"} - redis_server_allocator_active{node=\"$node\",cluster=\"$cluster\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1224,7 +1224,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "avg(redis_active_defrag_running{node=\"$node\",cluster=\"$cluster\"})/100",
+          "expr": "avg(redis_server_active_defrag_running{node=\"$node\",cluster=\"$cluster\"})/100",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1237,7 +1237,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(redis_process_resident_memory_bytes{node=\"$node\",cluster=\"$cluster\"}) - sum(redis_allocator_resident{node=\"$node\",cluster=\"$cluster\"})",
+          "expr": "sum(namedprocess_namegroup_memory_bytes{memtype=\"resident\", node=\"$node\",cluster=\"$cluster\"}) - sum(redis_server_allocator_resident{node=\"$node\",cluster=\"$cluster\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1252,7 +1252,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(redis_process_resident_memory_bytes{node=\"$node\",cluster=\"$cluster\"}) / sum(redis_allocator_resident{node=\"$node\",cluster=\"$cluster\"})",
+          "expr": "sum(namedprocess_namegroup_memory_bytes{memtype=\"resident\", node=\"$node\",cluster=\"$cluster\"}) / sum(redis_server_allocator_resident{node=\"$node\",cluster=\"$cluster\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1411,7 +1411,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, redis_used_ram{cluster=\"$cluster\", node=\"$node\"} or redis_used_memory{cluster=\"$cluster\", node=\"$node\"})",
+          "expr": "topk(10, redis_server_used_memory{cluster=\"$cluster\", node=\"$node\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1486,7 +1486,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(node_up,cluster)",
+          "query": "label_values(node_metrics_up,cluster)",
           "refId": "Redis-Enterprise-cluster-Variable-Query"
         },
         "refresh": 1,
@@ -1511,7 +1511,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(node_up{cluster=\"$cluster\"}, node)",
+          "query": "label_values(node_metrics_up{cluster=\"$cluster\"}, node)",
           "refId": "Redis-Enterprise-node-Variable-Query"
         },
         "refresh": 1,

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-shard-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-shard-dashboard_v9-11.json
@@ -6139,6 +6139,81 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
+      },
+      {
+        "auto": true,
+        "auto_count": 100,
+        "auto_min": "1m",
+        "current": {
+          "selected": false,
+          "text": "auto",
+          "value": "$__auto_interval_aggregation"
+        },
+        "hide": 0,
+        "label": "aggregation interval",
+        "name": "aggregation",
+        "options": [
+          {
+            "selected": true,
+            "text": "auto",
+            "value": "$__auto_interval_aggregation"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "14d",
+            "value": "14d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
+        ],
+        "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "queryValue": "",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
       }
     ]
   },

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-shard-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-shard-dashboard_v9-11.json
@@ -436,7 +436,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "scalar(scalar(redis_server_connected_clients{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}))",
+          "expr": "scalar(redis_server_connected_clients{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-shard-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-shard-dashboard_v9-11.json
@@ -3373,11 +3373,11 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_used_ram{bdb=\"$bdb\", cluster=\"$cluster\"}",
+              "expr": "redis_server_used_ram{db=\"$db\", cluster=\"$cluster\", role=\"master\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "bdb_used_ram",
+              "legendFormat": "Used RAM",
               "metric": "",
               "refId": "A",
               "step": 1200
@@ -3387,7 +3387,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_ram_limit{bdb=\"$bdb\", cluster=\"$cluster\"}",
+              "expr": "redis_server_max_ram{db=\"$db\", cluster=\"$cluster\", role=\"master\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "limit (when low, near used)",
@@ -3395,7 +3395,7 @@
               "step": 1200
             }
           ],
-          "title": "Used Memory(ROF) for $bdb",
+          "title": "Used Memory(ROF) for db",
           "type": "timeseries"
         },
         {
@@ -3555,7 +3555,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "(bdb_big_fetch_ram{bdb=\"$bdb\", cluster=\"$cluster\"} + bdb_big_write_ram{bdb=\"$bdb\", cluster=\"$cluster\"} + bdb_big_del_ram{bdb=\"$bdb\", cluster=\"$cluster\"}) / (bdb_big_fetch_flash{bdb=\"$bdb\", cluster=\"$cluster\"} + bdb_big_write_flash{bdb=\"$bdb\", cluster=\"$cluster\"} + bdb_big_del_flash{bdb=\"$bdb\", cluster=\"$cluster\"} + bdb_big_fetch_ram{bdb=\"$bdb\", cluster=\"$cluster\"} + bdb_big_write_ram{bdb=\"$bdb\", cluster=\"$cluster\"} + bdb_big_del_ram{bdb=\"$bdb\", cluster=\"$cluster\"}) > 0",
+              "expr": "avg by(db)((redis_server_ram_fetch_hit_ratio_ram{db=\"$db\", cluster=\"$cluster\"} + redis_server_ram_write_hit_ratio_ram{db=\"$db\", cluster=\"$cluster\"} + redis_server_ram_del_hit_ratio_ram{db=\"$db\", cluster=\"$cluster\"}) / (redis_server_ram_fetch_hit_ratio_flash{db=\"$db\", cluster=\"$cluster\"} + redis_server_ram_write_hit_ratio_flash{db=\"$db\", cluster=\"$cluster\"} + redis_server_ram_del_hit_ratio_flash{db=\"$db\", cluster=\"$cluster\"} + redis_server_ram_fetch_hit_ratio_ram{db=\"$db\", cluster=\"$cluster\"} + redis_server_ram_write_hit_ratio_ram{db=\"$db\", cluster=\"$cluster\"} + redis_server_ram_del_hit_ratio_ram{db=\"$db\", cluster=\"$cluster\"})) > 0",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "DB ram hit ratio",
@@ -3567,7 +3567,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_big_fetch_ram{bdb=\"$bdb\", cluster=\"$cluster\"}  / (bdb_big_fetch_flash{bdb=\"$bdb\", cluster=\"$cluster\"}  + bdb_big_fetch_ram{bdb=\"$bdb\", cluster=\"$cluster\"} ) > 0",
+              "expr": "(avg by (db)(redis_server_ram_fetch_hit_ratio_ram{cluster=\"$cluster\", db=\"$db\"} / (redis_server_ram_fetch_hit_ratio_flash{cluster=\"$cluster\", db=\"$db\"} + redis_server_ram_fetch_hit_ratio_ram{cluster=\"$cluster\", db=\"$db\"}))) > 0",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "read hit ratio",
@@ -3579,7 +3579,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_big_write_ram{bdb=\"$bdb\", cluster=\"$cluster\"}  / (bdb_big_write_flash{bdb=\"$bdb\", cluster=\"$cluster\"}  + bdb_big_write_ram{bdb=\"$bdb\", cluster=\"$cluster\"} ) > 0",
+              "expr": "avg by(db) (redis_server_ram_write_hit_ratio_ram{cluster=\"$cluster\", db=\"$db\"}/(redis_server_ram_write_hit_ratio_flash{cluster=\"$cluster\", db=\"$db\"}+redis_server_ram_write_hit_ratio_ram{cluster=\"$cluster\", db=\"$db\"})) > 0",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "write hit ratio",
@@ -3591,7 +3591,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_big_del_ram{bdb=\"$bdb\", cluster=\"$cluster\"}  / (bdb_big_del_flash{bdb=\"$bdb\", cluster=\"$cluster\"}  + bdb_big_del_ram{bdb=\"$bdb\", cluster=\"$cluster\"} ) > 0",
+              "expr": "avg by(db) (redis_server_ram_del_hit_ratio_ram{cluster=\"$cluster\", db=\"$db\"}/(redis_server_ram_del_hit_ratio_flash{cluster=\"$cluster\", db=\"$db\"}+redis_server_ram_del_hit_ratio_ram{cluster=\"$cluster\", db=\"$db\"})) > 0",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "del hit ratio",
@@ -3712,7 +3712,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "avg(delta(redis_big_io_ratio_redis{cluster=\"$cluster\",bdb=\"$bdb\",role=\"master\"}[1m]))/60",
+              "expr": "avg(delta(redis_server_big_io_ratio_redis{cluster=\"$cluster\",db=\"$db\",role=\"master\"}[1m]))/60",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "RAM Ops for Redis",
@@ -3724,7 +3724,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "avg(delta(redis_big_io_ratio_flash{cluster=\"$cluster\",bdb=\"$bdb\",role=\"master\"}[1m]) * -1)/60",
+              "expr": "avg(delta(redis_server_big_io_ratio_flash{cluster=\"$cluster\",db=\"$db\",role=\"master\"}[1m]) * -1)/60",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3737,7 +3737,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "avg(delta(redis_big_user_io_ratio_redis{cluster=\"$cluster\",bdb=\"$bdb\",role=\"master\"}[1m]))/60",
+              "expr": "avg(delta(redis_server_big_user_io_ratio_redis{cluster=\"$cluster\",db=\"$db\",role=\"master\"}[1m]))/60",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "User RAM Ops for Redis",
@@ -3749,7 +3749,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "avg(delta(redis_big_user_io_ratio_flash{cluster=\"$cluster\",bdb=\"$bdb\",role=\"master\"}[1m]) * -1)/60",
+              "expr": "avg(delta(redis_server_big_user_io_ratio_flash{cluster=\"$cluster\",db=\"$db\",role=\"master\"}[1m]) * -1)/60",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3852,7 +3852,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "delta(redis_big_io_ratio_redis{cluster=\"$cluster\",bdb=\"$bdb\"}[1m])/60",
+              "expr": "delta(redis_server_big_io_ratio_redis{cluster=\"$cluster\",db=\"$db\"}[1m])/60",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "RAM Ops for Redis {{redis}}",
@@ -3864,7 +3864,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "delta(redis_big_io_ratio_flash{cluster=\"$cluster\",bdb=\"$bdb\"}[1m]) / -60",
+              "expr": "delta(redis_server_big_io_ratio_flash{cluster=\"$cluster\",db=\"$db\"}[1m]) / -60",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3966,7 +3966,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_bigstore_io_read_bytes{bdb=\"$bdb\", cluster=\"$cluster\"}",
+              "expr": "avg by(db)(redis_server_big_io_reads{db=\"$db\", cluster=\"$cluster\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Reads",
@@ -3978,7 +3978,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_bigstore_io_write_bytes{bdb=\"$bdb\", cluster=\"$cluster\"}",
+              "expr": "avg by(db)(redis_server_big_io_writes{db=\"$db\", cluster=\"$cluster\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -4080,7 +4080,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_bigstore_io_reads{bdb=\"$bdb\", cluster=\"$cluster\"}",
+              "expr": "sum by (db)(redis_server_big_io_reads{db=\"$db\", cluster=\"$cluster\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Reads",
@@ -4092,7 +4092,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_bigstore_io_writes{bdb=\"$bdb\", cluster=\"$cluster\"}",
+              "expr": "sum by (db)(redis_server_big_io_writes{db=\"$db\", cluster=\"$cluster\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -4105,7 +4105,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_bigstore_io_dels{bdb=\"$bdb\", cluster=\"$cluster\"}",
+              "expr": "sum by (db)(redis_server_big_io_dels{db=\"$db\", cluster=\"$cluster\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Deletes",
@@ -4201,15 +4201,15 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(delta(redis_wait_busy_key{bdb=\"$bdb\",cluster=\"$cluster\"}[$aggregation]))",
+              "expr": "sum(delta(redis_server_wait_busy_key{db=\"$db\",cluster=\"$cluster\"}[$aggregation]))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "bdb:{{$bdb}}",
+              "legendFormat": "db:{{$db}}",
               "refId": "A",
               "step": 1200
             }
           ],
-          "title": "BDB sum redis wait busy key / $aggregation",
+          "title": "DB sum redis wait busy key / $aggregation",
           "type": "timeseries"
         },
         {
@@ -4297,15 +4297,15 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(delta(redis_blocking_reads{bdb=\"$bdb\",cluster=\"$cluster\"}[$aggregation]))",
+              "expr": "sum(delta(redis_server_blocking_reads{db=\"$db\",cluster=\"$cluster\"}[$aggregation]))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "bdb:{{$bdb}}",
+              "legendFormat": "db:{{$db}}",
               "refId": "A",
               "step": 1200
             }
           ],
-          "title": "BDB sum redis blocking reads / $aggregation",
+          "title": "DB sum redis blocking reads / $aggregation",
           "type": "timeseries"
         },
         {
@@ -4406,7 +4406,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_used_bigstore{bdb=\"$bdb\",cluster=\"$cluster\"}",
+              "expr": "sum by (db)(redis_server_used_disk{db=\"$db\",cluster=\"$cluster\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -4420,7 +4420,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_used_bigstore{bdb=\"$bdb\",cluster=\"$cluster\"} * bdb_disk_frag_ratio{bdb=\"$bdb\",cluster=\"$cluster\"}",
+              "expr": "sum by(db)(redis_server_used_disk{db=\"$db\",cluster=\"$cluster\"}) * avg by(db) (redis_server_disk_fragmentation_ratio{db=\"$db\",cluster=\"$cluster\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "actual",
@@ -4432,7 +4432,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_disk_frag_ratio{bdb=\"$bdb\",cluster=\"$cluster\"}",
+              "expr": "avg by (db)(redis_server_disk_fragmentation_ratio{db=\"$db\",cluster=\"$cluster\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -4441,7 +4441,7 @@
               "step": 1200
             }
           ],
-          "title": "BDB used flash",
+          "title": "DB used flash",
           "type": "timeseries"
         },
         {
@@ -4529,15 +4529,15 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_big_postponed_clients{cluster=\"$cluster\",bdb=\"$bdb\"}",
+              "expr": "sum by (db)(redis_server_big_inst_avg_io_postponed_clients{cluster=\"$cluster\",db=\"$db\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "bdb:{{$bdb}}",
+              "legendFormat": "db:{{$db}}",
               "refId": "A",
               "step": 1200
             }
           ],
-          "title": "BDB postponed clients",
+          "title": "DB postponed clients",
           "type": "timeseries"
         },
         {
@@ -4627,16 +4627,16 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_big_blocked_clients{bdb=\"$bdb\",cluster=\"$cluster\"}",
+              "expr": "sum by (db)(redis_server_big_inst_avg_io_blocked_clients{db=\"$db\",cluster=\"$cluster\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Number of blocked clients",
-              "metric": "bdb_big_blocked_clients",
+              "metric": "redis_server_big_inst_avg_io_blocked_clients",
               "refId": "A",
               "step": 1200
             }
           ],
-          "title": "BDB blocked clients",
+          "title": "DB blocked clients",
           "type": "timeseries"
         },
         {
@@ -4751,7 +4751,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_ram_overhead{cluster=\"$cluster\",bdb=\"$bdb\"} ",
+              "expr": "sum by (db)(redis_server_ram_overhead{cluster=\"$cluster\",db=\"$db\", role=\"master\"})  / sum by(db) (redis_server_used_ram{cluster=\"$cluster\",db=\"$db\",role=\"master\"})",
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
@@ -4764,7 +4764,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_ram_overhead{cluster=\"$cluster\",bdb=\"$bdb\"}  / bdb_ram_limit{cluster=\"$cluster\",bdb=\"$bdb\"}",
+              "expr": "sum by (db)(redis_server_ram_overhead{cluster=\"$cluster\",db=\"$db\", role=\"master\"})  / sum by(db) (redis_server_used_ram{cluster=\"$cluster\",db=\"$db\",role=\"master\"})",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -4777,16 +4777,16 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "redis_ram_overhead{cluster=\"$cluster\",bdb=\"$bdb\"} / redis_max_ram{cluster=\"$cluster\",bdb=\"$bdb\"}",
+              "expr": "sum by (db, role)(redis_server_ram_overhead{cluster=\"$cluster\",db=\"$db\"})  / sum by(db,role) (redis_server_max_ram{cluster=\"$cluster\",db=\"$db\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "redis: {{redis}} role:{{role}}",
+              "legendFormat": "db: {{db}} role:{{role}}",
               "refId": "C",
               "step": 1200
             }
           ],
-          "title": "BDB ram overhead",
+          "title": "DB ram overhead",
           "type": "timeseries"
         },
         {
@@ -4874,15 +4874,15 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(redis_blocking_writes{bdb=\"$bdb\",cluster=\"$cluster\"}[1m]))",
+              "expr": "sum by(db)(rate(redis_server_blocking_writes{db=\"$db\",cluster=\"$cluster\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "bdb:{{$bdb}}",
+              "legendFormat": "db:{{db}}",
               "refId": "A",
               "step": 1200
             }
           ],
-          "title": "BDB sum redis blocking writes",
+          "title": "DB sum redis blocking writes",
           "type": "timeseries"
         },
         {
@@ -4970,15 +4970,15 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(redis_big_inst_avg_read_io_queue{bdb=\"$bdb\",cluster=\"$cluster\"})",
+              "expr": "sum by (db)(redis_server_big_inst_avg_read_io_queue{db=\"$db\",cluster=\"$cluster\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "bdb:{{$bdb}}",
+              "legendFormat": "db:{{db}}",
               "refId": "A",
               "step": 1200
             }
           ],
-          "title": "BDB sum redis big inst avg read io queue",
+          "title": "DB sum redis big inst avg read io queue",
           "type": "timeseries"
         },
         {
@@ -5066,15 +5066,15 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(redis_big_inst_avg_write_io_queue{bdb=\"$bdb\",cluster=\"$cluster\"})",
+              "expr": "sum by (db)(redis_server_big_inst_avg_write_io_queue{db=\"$db\",cluster=\"$cluster\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "bdb:{{$bdb}}",
+              "legendFormat": "db:{{db}}",
               "refId": "A",
               "step": 1200
             }
           ],
-          "title": "BDB sum redis big inst avg write io queue",
+          "title": "DB sum redis big inst avg write io queue",
           "type": "timeseries"
         },
         {
@@ -5162,7 +5162,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_bigstore_objs_flash{bdb=\"$bdb\",cluster=\"$cluster\"}",
+              "expr": "sum by(db)(redis_server_bigdb_disk{db=\"$db\",cluster=\"$cluster\", role=\"master\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -5176,7 +5176,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_bigstore_objs_ram{bdb=\"$bdb\",cluster=\"$cluster\"}",
+              "expr": "sum by (db)(redis_server_bigdb_ram{db=\"$db\",cluster=\"$cluster\", role=\"master\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "objects in ram (sum of all master shards)",
@@ -5184,7 +5184,7 @@
               "step": 1200
             }
           ],
-          "title": "BDB objects(values) in FLASH",
+          "title": "DB objects(values) in FLASH",
           "type": "timeseries"
         },
         {
@@ -5248,7 +5248,7 @@
               {
                 "matcher": {
                   "id": "byRegexp",
-                  "options": "/BDB.*/"
+                  "options": "/DB.*/"
                 },
                 "properties": [
                   {
@@ -5321,12 +5321,12 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_bigstore_objs_ram{bdb=\"$bdb\",cluster=\"$cluster\"} / bdb_no_of_keys{bdb=\"$bdb\",cluster=\"$cluster\"} ",
+              "expr": "sum by(db,cluster)(redis_server_bigdb_ram{db=\"$db\",cluster=\"$cluster\", role=\"master\"}) / sum by (db,cluster)(redis_server_db_keys{db=\"$db\",cluster=\"$cluster\",role=\"master\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "BDB % values in RAM (masters)",
+              "legendFormat": "DB % values in RAM (masters)",
               "metric": "",
               "refId": "A",
               "step": 1200
@@ -5336,7 +5336,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "avg((max(redis_bigdb0_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"} or redis_bigdb_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"}) by (redis,bdb,cluster)) / on (redis,bdb,cluster) redis_db0_keys{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"})",
+              "expr": "avg((max(redis_server_bigdb_ram{db=\"$db\",cluster=\"$cluster\",role=\"master\"}) by (redis,db,cluster)) / on (redis,db,cluster) redis_server_db_keys{db=\"$db\",cluster=\"$cluster\",role=\"master\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -5350,7 +5350,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "avg((max(redis_bigdb0_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"} or redis_bigdb_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"}) by (redis,bdb,cluster)) / on (redis,bdb,cluster) redis_db0_keys{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"})",
+              "expr": "avg((max(redis_server_bigdb_ram{db=\"$db\",cluster=\"$cluster\",role=\"slave\"}) by (redis,db,cluster)) / on (redis,db,cluster) redis_server_db_keys{db=\"$db\",cluster=\"$cluster\",role=\"slave\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -5364,12 +5364,12 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "topk(1, min((max(redis_bigdb0_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"} or redis_bigdb_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"}) by (redis,bdb,cluster)) / on (redis,bdb,cluster) redis_db0_keys{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"}) by (redis) * -1) *-1",
+              "expr": "topk(1, min((max(redis_server_bigdb_ram{db=\"$db\",cluster=\"$cluster\",role=\"master\"}) by (redis,db,cluster)) / on (redis,db,cluster) redis_server_db_keys{db=\"$db\",cluster=\"$cluster\",role=\"master\"}) by (redis) * -1) *-1",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "lowest master shard % values in RAM - redsi:{{redis}}",
+              "legendFormat": "lowest master shard % values in RAM - redis:{{redis}}",
               "refId": "F",
               "step": 1200
             },
@@ -5378,10 +5378,10 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "topk(1, min((max(redis_bigdb0_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"} or redis_bigdb_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"}) by (redis,bdb,cluster)) / on (redis,bdb,cluster) redis_db0_keys{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"}) by (redis) * -1) *-1",
+              "expr": "topk(1, min((max(redis_server_bigdb_ram{db=\"$db\",cluster=\"$cluster\",role=\"slave\"}) by (redis,db,cluster)) / on (redis,db,cluster) redis_server_db_keys{db=\"$db\",cluster=\"$cluster\",role=\"slave\"}) by (redis) * -1) *-1",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "lowest slave shard % values in RAM - redsi:{{redis}}",
+              "legendFormat": "lowest slave shard % values in RAM - redis:{{redis}}",
               "refId": "G",
               "step": 1200
             },
@@ -5390,7 +5390,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "min(redis_bigdb0_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"} / redis_bigdb0_keys{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"})",
+              "expr": "min(redis_server_bigdb_ram{db=\"$db\",cluster=\"$cluster\",role=\"master\"} / redis_server_db_keys{db=\"$db\",cluster=\"$cluster\",role=\"master\"})",
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
@@ -5403,7 +5403,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "min(redis_bigdb0_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"} / redis_bigdb0_keys{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"})",
+              "expr": "min(redis_server_bigdb_ram{db=\"$db\",cluster=\"$cluster\",role=\"slave\"} / redis_server_db_keys{db=\"$db\",cluster=\"$cluster\",role=\"slave\"})",
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
@@ -5412,7 +5412,7 @@
               "step": 10
             }
           ],
-          "title": "BDB % values in RAM",
+          "title": "DB % values in RAM",
           "type": "timeseries"
         },
         {
@@ -5531,12 +5531,12 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_bigstore_objs_ram{bdb=\"$bdb\",cluster=\"$cluster\"}",
+              "expr": "sum by (cluster,db,redis) (redis_server_bigdb_ram{db=\"$db\",cluster=\"$cluster\",role=\"master\"})",
               "format": "time_series",
               "hide": true,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "bdb:{{$bdb}} (sum of masters)",
+              "legendFormat": "db:{{db}} (sum of masters)",
               "metric": "",
               "refId": "A",
               "step": 10
@@ -5546,7 +5546,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "avg(max(redis_bigdb0_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"} or redis_bigdb_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"}) by (redis,bdb,cluster))",
+              "expr": "avg(max(redis_server_bigdb_ram{db=\"$db\",cluster=\"$cluster\",role=\"slave\"}))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -5560,7 +5560,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "avg(max(redis_bigdb0_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"} or redis_bigdb_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"}) by (redis,bdb,cluster))",
+              "expr": "avg(max(redis_server_bigdb_ram{db=\"$db\",cluster=\"$cluster\",role=\"master\"}))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -5574,7 +5574,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "min(max(redis_bigdb0_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"} or redis_bigdb_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"}) by (redis,bdb,cluster))",
+              "expr": "avg(max(redis_server_bigdb_ram{db=\"$db\",cluster=\"$cluster\",role=\"slave\"}))",
               "format": "time_series",
               "hide": true,
               "interval": "",
@@ -5588,7 +5588,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "min(max(redis_bigdb0_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"} or redis_bigdb_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"}) by (redis,bdb,cluster))",
+              "expr": "avg(max(redis_server_bigdb_ram{db=\"$db\",cluster=\"$cluster\",role=\"master\"}))",
               "format": "time_series",
               "hide": true,
               "interval": "",
@@ -5602,7 +5602,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "topk(1, min(max(redis_bigdb0_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"} or redis_bigdb_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"}) by (redis,bdb,cluster) < on(cluster,bdb,redis) redis_db0_keys{bdb=\"$bdb\",cluster=\"$cluster\",role=\"slave\"} ) by (bdb, redis) * -1) * -1",
+              "expr": "min by(redis)(redis_server_bigdb_ram{role=\"slave\", cluster=\"$cluster\", db=\"$db\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -5616,7 +5616,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "topk(1, min(max(redis_bigdb0_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"} or redis_bigdb_ram{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"}) by (redis,bdb,cluster) < on(cluster,bdb,redis) redis_db0_keys{bdb=\"$bdb\",cluster=\"$cluster\",role=\"master\"}) by (bdb, redis) * -1) * -1",
+              "expr": "min by(redis)(redis_server_bigdb_ram{role=\"master\", cluster=\"$cluster\", db=\"$db\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -5714,16 +5714,16 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_big_ram_dirty_evictions{bdb=\"$bdb\",cluster=\"$cluster\"}",
+              "expr": "redis_server_ram_dirty_evictions{db=\"$db\",cluster=\"$cluster\", role=\"master\"}",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "bdb:{{$bdb}}",
+              "legendFormat": "db:{{db}}",
               "metric": "",
               "refId": "A",
               "step": 1200
             }
           ],
-          "title": "BDB dirty RAM evictions",
+          "title": "DB dirty RAM evictions",
           "type": "timeseries"
         },
         {
@@ -5811,16 +5811,16 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "bdb_big_ram_clean_evictions{bdb=\"$bdb\",cluster=\"$cluster\"}",
+              "expr": "redis_server_ram_clean_evictions{db=\"$db\",cluster=\"$cluster\", role=\"master\"}",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "bdb:{{$bdb}}",
+              "legendFormat": "db:{{db}}",
               "metric": "",
               "refId": "A",
               "step": 1200
             }
           ],
-          "title": "BDB clean RAM evictions",
+          "title": "DB clean RAM evictions",
           "type": "timeseries"
         },
         {
@@ -5934,7 +5934,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(delta(redis_rocks_comp_started{bdb=\"$bdb\", cluster=\"$cluster\"}[1m]))",
+              "expr": "sum(delta(redis_server_rocks_comp_started{db=\"$db\", cluster=\"$cluster\", role=\"master\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "compactions",
@@ -5947,7 +5947,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(delta(redis_rocks_flush_started{bdb=\"$bdb\", cluster=\"$cluster\"}[1m]))",
+              "expr": "sum(delta(redis_server_rocks_flush_started{db=\"$db\", cluster=\"$cluster\"}[1m]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -5960,7 +5960,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(delta(redis_rocks_flush_writes_slowdown{bdb=\"$bdb\", cluster=\"$cluster\"}[$aggregation]))",
+              "expr": "sum(delta(redis_server_rocks_flush_writes_slowdown{db=\"$db\", cluster=\"$cluster\"}[$aggregation]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -5974,7 +5974,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(delta(redis_rocks_flush_writes_stop{bdb=\"$bdb\", cluster=\"$cluster\"}[$aggregation]))",
+              "expr": "sum(delta(redis_server_rocks_flush_writes_stop{db=\"$db\", cluster=\"$cluster\"}[$aggregation]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -5997,7 +5997,7 @@
           "refId": "A"
         }
       ],
-      "title": "$bdb : shard $shard : ROF Metrics",
+      "title": "$db : shard $shard : ROF Metrics",
       "type": "row"
     }
   ],
@@ -6036,53 +6036,6 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "bdb_conns{cluster=\"$cluster\"}",
-        "hide": 0,
-        "includeAll": false,
-        "label": "bdb_database",
-        "multi": false,
-        "name": "bdb",
-        "options": [],
-        "query": {
-          "query": "bdb_conns{cluster=\"$cluster\"}",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "/bdb_name=\"(?<text>[^\"]+)|bdb=\"(?<value>[^\"]+)/g",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(redis_up{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}, status)",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "status",
-        "options": [],
-        "query": {
-          "query": "label_values(redis_up{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}, status)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
         "definition": "",
         "hide": 2,
         "includeAll": false,
@@ -6090,7 +6043,7 @@
         "name": "newStatus",
         "options": [],
         "query": {
-          "query": "label_values(bdb_up{bdb=\"$bdb\", cluster=\"$cluster\"}, status)",
+          "query": "label_values(redis_server_connected_clients{db=\"$db\", cluster=\"$cluster\"}, status)",
           "refId": "Redis-Enterprise-newStatus-Variable-Query"
         },
         "refresh": 1,

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-shard-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-shard-dashboard_v9-11.json
@@ -88,7 +88,7 @@
         "y": 0
       },
       "id": 72,
-      "title": "$bdb : shard $shard : Summary",
+      "title": "$db : shard $shard : Summary",
       "type": "row"
     },
     {
@@ -201,7 +201,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "scalar(redis_process_cpu_usage_percent{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"})",
+          "expr": "scalar(sum by(db)(irate(namedprocess_namegroup_cpu_seconds_total{mode=~\"system|user\", cluster=\"$cluster\",db=\"$db\", redis=\"$shard\"}[1m])))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -284,7 +284,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "scalar(redis_used_memory{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"})",
+          "expr": "scalar(redis_server_used_memory{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -367,7 +367,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_db0_keys{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "redis_server_db_keys{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -436,7 +436,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "scalar(redis_connected_clients{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"})",
+          "expr": "scalar(scalar(redis_server_connected_clients{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -517,7 +517,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(redis_forwarding_state{cluster=\"$cluster\", bdb=\"$bdb\", redis=\"$shard\"})",
+          "expr": "count(redis_server_forwarding_state{cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -552,7 +552,7 @@
           "refId": "A"
         }
       ],
-      "title": "$bdb : shard $shard : Memory",
+      "title": "$db : shard $shard : Memory",
       "type": "row"
     },
     {
@@ -670,7 +670,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_maxmemory{cluster=\"$cluster\", bdb=\"$bdb\", redis=\"$shard\"}",
+          "expr": "redis_server_maxmemory{cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -799,7 +799,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_allocator_allocated{cluster=\"$cluster\", bdb=\"$bdb\", redis=\"$shard\"}",
+          "expr": "redis_server_allocator_allocated{cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -928,7 +928,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_allocator_allocated{cluster=\"$cluster\", bdb=\"$bdb\", redis=\"$shard\"}",
+          "expr": "redis_server_allocator_resident{cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1057,7 +1057,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_allocator_allocated{cluster=\"$cluster\", bdb=\"$bdb\", redis=\"$shard\"}",
+          "expr": "redis_server_allocator_allocated{cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1186,7 +1186,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_mem_fragmentation_ratio{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "redis_server_mem_fragmentation_ratio{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1316,7 +1316,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_mem_aof_buffer{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "redis_server_mem_aof_buffer{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1446,7 +1446,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_mem_not_counted_for_evict{cluster=\"$cluster\", bdb=\"$bdb\", redis=\"$shard\"}",
+          "expr": "redis_server_mem_not_counted_for_evict{cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1576,7 +1576,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_mem_replication_backlog{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "redis_server_mem_replication_backlog{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1613,7 +1613,7 @@
           "refId": "A"
         }
       ],
-      "title": "$bdb : shard $shard : CPU",
+      "title": "$db : shard $shard : CPU",
       "type": "row"
     },
     {
@@ -1705,7 +1705,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_process_cpu_system_seconds_total{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "namedprocess_namegroup_cpu_seconds_total{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\", mode=\"system\"}",
           "hide": false,
           "legendFormat": "System CPU",
           "range": true,
@@ -1717,7 +1717,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_process_cpu_user_seconds_total{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "namedprocess_namegroup_cpu_seconds_total{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\", mode=\"user\"}",
           "hide": false,
           "legendFormat": "User CPU",
           "range": true,
@@ -1820,7 +1820,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_process_cpu_usage_percent{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "sum by (redis)(rate(namedprocess_namegroup_cpu_seconds_total{mode=~\"system|user\", redis=\"$shard\", cluster=\"$cluster\", db=\"$db\"}[1m])) * 100",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -1943,7 +1943,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_process_main_thread_cpu_system_seconds_total{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "namedprocess_namegroup_cpu_seconds_total{redis=\"$shard\", mode=\"system\", cluster=\"$cluster\", db=\"$db\"}",
           "hide": false,
           "legendFormat": "Main Thread - System",
           "range": true,
@@ -1955,7 +1955,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_process_main_thread_cpu_user_seconds_total{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "namedprocess_namegroup_cpu_seconds_total{redis=\"$shard\", mode=\"user\", cluster=\"$cluster\", db=\"$db\"}",
           "hide": false,
           "legendFormat": "Main Thread - User",
           "range": true,
@@ -1988,7 +1988,7 @@
           "refId": "A"
         }
       ],
-      "title": "$bdb : shard $shard : Network",
+      "title": "$db : shard $shard : Network",
       "type": "row"
     },
     {
@@ -2083,7 +2083,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_connected_clients{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "redis_server_connected_clients{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"} ",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -2219,22 +2219,10 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_connected_clients{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "redis_server_total_commands_processed{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}",
           "legendFormat": "Connected Clients",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "builder",
-          "expr": "redis_blocked_clients{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
-          "hide": false,
-          "legendFormat": "Blocked Clients",
-          "range": true,
-          "refId": "B"
         }
       ],
       "title": "Commands Processed",
@@ -2344,7 +2332,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_total_net_output_bytes{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "redis_server_total_net_output_bytes{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Egress",
@@ -2358,7 +2346,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_total_net_input_bytes{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "redis_server_total_net_input_bytes{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Ingress",
@@ -2393,7 +2381,7 @@
           "refId": "A"
         }
       ],
-      "title": "$bdb : shard $shard : Keys",
+      "title": "$db : shard $shard : Keys",
       "type": "row"
     },
     {
@@ -2486,8 +2474,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_no_of_keys{cluster=\"$cluster\", bdb=\"$bdb\"} or redis_db0_keys{cluster=\"$cluster\", bdb=\"$bdb\"}",
           "format": "time_series",
+          "expr": "(sum by (db) (redis_server_db_keys{role=\"master\", cluster=\"$cluster\", db=\"$db\"})) / (count by(db) (redis_server_db_keys{role=\"maste\", cluster=\"$cluster\", db=\"$db\"}))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "shard:{{redis}}, role: {{role}}, node:{{node}}, slots:{{slots}}",
@@ -2591,7 +2579,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "redis_db0_keys{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "redis_server_db_keys{cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"}",
           "hide": false,
           "legendFormat": "shard: {{redis}}",
           "range": true,
@@ -2689,7 +2677,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_evicted_keys{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "redis_server_evicted_keys{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "shard: {{redis}}",
@@ -2790,7 +2778,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_expired_keys{bdb=\"$bdb\", cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "redis_server_expired_keys{db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "shard: {{redis}}",
@@ -2826,7 +2814,7 @@
           "refId": "A"
         }
       ],
-      "title": "$bdb : shard $shard : Cache",
+      "title": "$db : shard $shard : Cache",
       "type": "row"
     },
     {
@@ -2915,7 +2903,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(redis_mem_fragmentation_ratio{bdb=\"$bdb\",cluster=\"$cluster\", redis=\"$shard\"}) / count(redis_mem_fragmentation_ratio{bdb=\"$bdb\",cluster=\"$cluster\", redis=\"$shard\"})",
+          "expr": "sum(redis_server_mem_fragmentation_ratio{db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"}) / count(redis_server_mem_fragmentation_ratio{db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "redis_mem_fragmentation_ratio",
@@ -2930,7 +2918,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(redis_allocator_active{bdb=\"$bdb\",cluster=\"$cluster\", redis=\"$shard\"}) / sum(redis_allocator_allocated{bdb=\"$bdb\",cluster=\"$cluster\", redis=\"$shard\"})",
+          "expr": "sum(redis_server_allocator_active{db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"}) / sum(redis_server_allocator_allocated{db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Shard allocator fragmentation",
@@ -2944,7 +2932,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(redis_allocator_resident{bdb=\"$bdb\",cluster=\"$cluster\", redis=\"$shard\"}) / sum(redis_allocator_active{bdb=\"$bdb\",cluster=\"$cluster\", redis=\"$shard\"})",
+          "expr": "sum(redis_server_allocator_resident{db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"}) / sum(redis_server_allocator_active{db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -3045,7 +3033,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_mem_fragmentation_ratio{cluster=\"$cluster\", bdb=\"$bdb\", redis=\"$shard\"} ",
+          "expr": "redis_server_mem_fragmentation_ratio{cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"} ",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -3147,7 +3135,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_allocator_active{bdb=\"$bdb\",cluster=\"$cluster\", redis=\"$shard\"} - redis_allocator_allocated{bdb=\"$bdb\",cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "redis_server_allocator_active{db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"} - redis_server_allocator_allocated{db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -3249,7 +3237,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "redis_allocator_active{bdb=\"$bdb\",cluster=\"$cluster\", redis=\"$shard\"} / redis_allocator_allocated{bdb=\"$bdb\",cluster=\"$cluster\", redis=\"$shard\"}",
+          "expr": "redis_server_allocator_active{db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"} / redis_server_allocator_allocated{db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -6051,7 +6039,7 @@
         "definition": "bdb_conns{cluster=\"$cluster\"}",
         "hide": 0,
         "includeAll": false,
-        "label": "database",
+        "label": "bdb_database",
         "multi": false,
         "name": "bdb",
         "options": [],
@@ -6114,11 +6102,28 @@
       },
       {
         "current": {},
+        "definition": "label_values(endpoint_client_connections{cluster=\"$cluster\"},db)",
+        "description": "endpoint_client_connections{cluster=\"$cluster\"}",
+        "label": "database",
+        "name": "db",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(endpoint_client_connections{cluster=\"$cluster\"},db)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
         "datasource": {
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(redis_up{cluster=\"$cluster\", bdb=\"$bdb\"}, redis)",
+        "definition": "label_values(redis_up{cluster=\"$cluster\", db=\"$db\"}, redis)",
         "hide": 0,
         "includeAll": false,
         "label": "shard",
@@ -6126,7 +6131,7 @@
         "name": "shard",
         "options": [],
         "query": {
-          "query": "label_values(redis_up{cluster=\"$cluster\", bdb=\"$bdb\"}, redis)",
+          "query": "label_values(redis_up{cluster=\"$cluster\", db=\"$db\"}, redis)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/grafana_v2/kickstart_v2/docker-compose.yml
+++ b/grafana_v2/kickstart_v2/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - "3000:3000"
     depends_on:
       - prometheus
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       kickstart:
         ipv4_address: "172.27.2.3"


### PR DESCRIPTION
Issue when deploying this to a linux VM,

host.docker.internal is not enabled by default (hence when it tries to reach 9090 on the local host it sees nothing), adding this to extra hosts fixes the problem. Other possible solution would be to use the internal docker network's DNS record for prometheus (which would just be `prometheus`).