### PR TITLE
Update Grafana v2 software cluster connections billboard

### DIFF
--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json
@@ -135,13 +135,13 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "sum(endpoint_client_connections{cluster=\"$cluster\"})",
-          "legendFormat": "__auto",
+          "expr": "scalar(count(count by (db) (endpoint_client_connections{cluster=\"$cluster\"})))",
+          "legendFormat": "count",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Endpoint Client Connections",
+      "title": "Database Count",
       "type": "stat"
     },
     {

--- a/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json
@@ -135,13 +135,13 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "count(redis_server_up{cluster=\"$cluster\"})",
-          "legendFormat": "count",
+          "expr": "sum(endpoint_client_connections{cluster=\"$cluster\"})",
+          "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Database Count",
+      "title": "Endpoint Client Connections",
       "type": "stat"
     },
     {


### PR DESCRIPTION
## Summary
- replace the first stat in the Grafana v2 software cluster dashboard with an endpoint client connections query
- rename the panel from Database Count to Endpoint Client Connections
- keep the panel as a single-stat billboard by aggregating the metric with sum

## Validation
- jq empty grafana_v2/dashboards/grafana_v9-11/software/basic/redis-software-cluster-dashboard_v9-11.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dashboard-only change that swaps a PromQL expression; main risk is showing an incorrect value if the new metric/aggregation doesn’t match the intended meaning.
> 
> **Overview**
> Updates the `redis-software-cluster-dashboard_v9-11.json` “Database Count” stat to use `endpoint_client_connections` (counting distinct `db` labels via `scalar(count(count by (db) (...)))`) instead of `count(redis_server_up{...})`, changing what that billboard represents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d274084282824fb74fedb2d781eda924a7af05ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->