### PR TITLE
Fix Grafana v2 ops dashboard latency panel ordering

### DIFF
--- a/grafana_v2/dashboards/grafana_v9-11/software/ops/database.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/ops/database.json
@@ -3017,7 +3017,7 @@
         "gridPos": {
           "h": 11,
           "w": 8,
-          "x": 0,
+          "x": 16,
           "y": 65
         },
         "id": 78,
@@ -3175,7 +3175,7 @@
               "uid": "${DS_PROMETHEUS}"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.90, sum(rate(endpoint_write_requests_latency_histogram_bucket{cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+            "expr": "histogram_quantile(0.99, sum(rate(endpoint_write_requests_latency_histogram_bucket{cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
             "hide": false,
             "legendFormat": "Write",
             "range": true,
@@ -3259,7 +3259,7 @@
         "gridPos": {
           "h": 11,
           "w": 8,
-          "x": 16,
+          "x": 0,
           "y": 65
         },
         "id": 79,

--- a/grafana_v2/dashboards/grafana_v9-11/software/ops/database.json
+++ b/grafana_v2/dashboards/grafana_v9-11/software/ops/database.json
@@ -3163,7 +3163,7 @@
               "uid": "${DS_PROMETHEUS}"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.90, sum(rate(endpoint_read_requests_latency_histogram_bucket{cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+            "expr": "histogram_quantile(0.99, sum(rate(endpoint_read_requests_latency_histogram_bucket{cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
             "format": "time_series",
             "legendFormat": "Read",
             "range": true,
@@ -3187,7 +3187,7 @@
               "uid": "${DS_PROMETHEUS}"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.90, sum(rate(endpoint_other_requests_latency_histogram_bucket{cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+            "expr": "histogram_quantile(0.99, sum(rate(endpoint_other_requests_latency_histogram_bucket{cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
             "hide": false,
             "legendFormat": "Other",
             "range": true,


### PR DESCRIPTION
Summary:
- fix the Grafana v2 ops database dashboard p99 latency panel to query p99 instead of p90
- reorder the database dashboard latency percentile panels so they progress in ascending quantile order, matching the latency dashboard

Details:
- database dashboard latency panels now read left-to-right as p50, p99, p99.9
- latency dashboard was already ordered ascending, so no changes were needed there
- this keeps the dashboards consistent and removes the mislabeled p99 panel behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dashboard-only JSON changes that adjust Prometheus quantiles and panel layout without affecting runtime code paths.
> 
> **Overview**
> Fixes the ops `database.json` latency section so the panel labeled **p99** actually queries `histogram_quantile(0.99, ...)` (previously `0.90`) for read/write/other request latency.
> 
> Reorders the latency percentile panels by swapping their `gridPos.x` positions so they display left-to-right in ascending quantile order (p50, p99, p99.9).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 180deb363621995cc460df34653e304d28dd0a10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->