### PR TITLE
[codex] Add OpenShift native Observe dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository provides pre-built dashboards, metrics configurations, and integ
 - **New Relic** - Application performance monitoring
 - **Splunk** - Log analytics and SIEM
 - **Kibana** - Elasticsearch visualization
+- **[OpenShift](openshift/native-observe/README.md)** - Native Observe dashboards and alerting
 
 ## Documentation
 

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -13,6 +13,7 @@
 * xref:dashboards/catalog.adoc[Dashboard Catalog]
 
 .Guides
+* xref:guides/openshift-native-observe-dashboards.adoc[OpenShift: Native Observe Dashboards]
 * xref:guides/monitoring-redis-cloud.adoc[Monitoring Redis Cloud]
 * xref:guides/alerting.adoc[Alerting]
 * xref:guides/troubleshooting.adoc[Troubleshooting]

--- a/docs/modules/ROOT/pages/guides/openshift-native-observe-dashboards.adoc
+++ b/docs/modules/ROOT/pages/guides/openshift-native-observe-dashboards.adoc
@@ -1,0 +1,301 @@
+= OpenShift Native Observe Dashboards
+
+Use OpenShift's native Observe UI to view Redis Enterprise dashboards without deploying a separate Grafana instance.
+
+This guide installs:
+
+* A `ServiceMonitor` that scrapes an in-cluster Redis Enterprise metrics service on `https://<service>:8070/v2`
+* A `PrometheusRule` that exposes Redis Enterprise alerts in OpenShift Observe
+* Redis Enterprise dashboard `ConfigMap` resources for OpenShift Observe -> Dashboards
+
+The dashboards are legacy OpenShift dashboard `ConfigMap` resources. They are curated from the Grafana v2 software basic and ops dashboards in this repository, but they intentionally omit Grafana-only panel types and transformations that do not render reliably in the OpenShift legacy dashboard UI.
+
+For a customer-facing active-active deployment runbook using Redis Enterprise clusters in `ns-a` and `ns-b`, see `openshift/native-observe/RUNBOOK.md`.
+
+== Prerequisites
+
+* OpenShift CLI (`oc`) installed and logged in
+* User workload monitoring enabled in OpenShift
+* Permission to create `ServiceMonitor` and `PrometheusRule` resources in the Redis Enterprise namespace
+* Permission to create `ConfigMap` resources in `openshift-config-managed`
+* Redis Enterprise deployed in OpenShift with a metrics service such as `rec-prom`, `rec-a-prom`, or `rec-b-prom`
+* This repository cloned locally
+
+Run commands from the repository root:
+
+[source,bash]
+----
+cd /path/to/redis-enterprise-observability
+----
+
+== Step 1: Enable User Workload Monitoring
+
+OpenShift must collect metrics from user namespaces before the dashboards can show Redis Enterprise data.
+
+Cluster administrators enable user workload monitoring with `enableUserWorkload: true` in the `cluster-monitoring-config` `ConfigMap`:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+----
+
+After the setting is applied, confirm that the user workload monitoring stack is running:
+
+[source,bash]
+----
+oc -n openshift-user-workload-monitoring get pods
+----
+
+You should see `prometheus-user-workload` and `thanos-ruler-user-workload` pods.
+
+== Step 2: Prepare the Redis Enterprise Metrics Service
+
+Set the namespace and service name for your Redis Enterprise metrics service:
+
+[source,bash]
+----
+export REDIS_NS=redis-enterprise
+export REDIS_METRICS_SERVICE=rec-prom
+----
+
+For active-active examples, the service names might be `rec-a-prom` and `rec-b-prom` in their respective namespaces.
+
+Check that the service exists and has endpoints:
+
+[source,bash]
+----
+oc -n "${REDIS_NS}" get svc "${REDIS_METRICS_SERVICE}"
+oc -n "${REDIS_NS}" get endpoints "${REDIS_METRICS_SERVICE}" -o wide
+----
+
+Confirm that the service has the Redis Enterprise metrics label and the expected service port name:
+
+[source,bash]
+----
+oc -n "${REDIS_NS}" get svc "${REDIS_METRICS_SERVICE}" \
+  -o jsonpath='{.metadata.labels.redis\.io/service}{"\n"}{.spec.ports[?(@.port==8070)].name}{"\n"}'
+----
+
+Expected output:
+
+[source,text]
+----
+prom-metrics
+prometheus
+----
+
+The provided `ServiceMonitor` selects `redis.io/service=prom-metrics` and service port `prometheus`, which matches Redis Enterprise operator-created metrics services.
+
+== Step 3: Apply the ServiceMonitor and Alerts
+
+The manifests default to the namespace `redis-enterprise`. To apply them to a different namespace without editing the files, use `yq`:
+
+[source,bash]
+----
+REDIS_NS="${REDIS_NS}" yq eval '.metadata.namespace = env(REDIS_NS)' \
+  openshift/native-observe/redis-enterprise-servicemonitor.yaml | oc apply -f -
+
+REDIS_NS="${REDIS_NS}" yq eval '.metadata.namespace = env(REDIS_NS)' \
+  openshift/native-observe/redis-enterprise-prometheusrule.yaml | oc apply -f -
+----
+
+The `ServiceMonitor` uses:
+
+* `scheme: https`
+* `path: /v2`
+* `port: prometheus`
+* `interval: 30s`
+* `tlsConfig.insecureSkipVerify: true`
+
+For production, replace `insecureSkipVerify: true` with the correct trust configuration whenever your Redis Enterprise metrics endpoint presents a certificate signed by a known CA.
+
+=== Optional Metrics Authentication
+
+The provided manifest assumes the Redis Enterprise metrics endpoint does not require authentication.
+
+If your endpoint requires basic authentication, create a secret in the same namespace as the `ServiceMonitor`:
+
+[source,bash]
+----
+oc -n "${REDIS_NS}" create secret generic redis-metrics-auth \
+  --from-literal=username='prometheus' \
+  --from-literal=password='replace-with-your-password'
+----
+
+Then add this block under the first item in `spec.endpoints` in `redis-enterprise-servicemonitor.yaml`:
+
+[source,yaml]
+----
+      basicAuth:
+        username:
+          name: redis-metrics-auth
+          key: username
+        password:
+          name: redis-metrics-auth
+          key: password
+----
+
+== Step 4: Confirm Metrics Are Available
+
+In the OpenShift web console, go to Observe -> Metrics and run:
+
+[source,promql]
+----
+redis_server_up{namespace="redis-enterprise"}
+----
+
+Also check representative metrics used by the dashboards:
+
+[source,promql]
+----
+node_metrics_up{namespace="redis-enterprise"}
+endpoint_client_connections{namespace="redis-enterprise"}
+----
+
+From the CLI, you can check whether the scrape target is up:
+
+[source,bash]
+----
+oc -n "${REDIS_NS}" get servicemonitor redis-enterprise-observe
+----
+
+If metrics do not appear, check the user workload Prometheus logs:
+
+[source,bash]
+----
+oc -n openshift-user-workload-monitoring logs statefulset/prometheus-user-workload -c prometheus --tail=100
+----
+
+== Step 5: Install the Observe Dashboards
+
+Install the dashboard `ConfigMap` resources:
+
+[source,bash]
+----
+oc apply -f openshift/native-observe/dashboards/
+----
+
+Then open the OpenShift web console and go to Observe -> Dashboards.
+
+The following dashboards should appear:
+
+* Redis Enterprise / Basic / Cluster Status Dashboard
+* Redis Enterprise / Basic / Database Status Dashboard
+* Redis Enterprise / Basic / Node Dashboard
+* Redis Enterprise / Basic / Shard Dashboard
+* Redis Enterprise / Basic / Active-Active
+* Redis Enterprise / Basic / Synchronization (Classic)
+* Redis Enterprise / Ops / Cluster Dashboard
+* Redis Enterprise / Ops / Database Dashboard
+* Redis Enterprise / Ops / Node Dashboard
+* Redis Enterprise / Ops / Shard dashboard
+* Redis Enterprise / Ops / Latency Dashboard
+* Redis Enterprise / Ops / Active-Active Lag
+* Redis Enterprise / Ops / RediSearch QPS dashboard
+
+Each dashboard includes a `namespace` variable. Select the Redis Enterprise namespace first, then select the relevant cluster, database, node, shard, or CRDT filters.
+
+== What Is Included and Omitted
+
+Included panel mappings:
+
+* Grafana `timeseries` panels are converted to legacy OpenShift `graph` panels
+* Grafana `stat` panels are converted to legacy `singlestat` panels when they do not depend on value mappings or advanced transformations
+* Grafana `table` panels are included only when they do not depend on transformations
+
+Omitted panel features:
+
+* Grafana `gauge`, `bargauge`, `piechart`, `link`, and `text` panels
+* Panels that require Grafana transformations
+* Panels that rely on Grafana value mappings
+* Dashboard links and workflow navigation links
+* Plugin-specific features
+
+These omissions are intentional. The goal is to keep the native OpenShift dashboards renderable and supportable in the legacy dashboard UI rather than carrying over Grafana features that the console does not reliably support.
+
+== Static Validation
+
+Validate the dashboard JSON embedded in each `ConfigMap`:
+
+[source,bash]
+----
+for file in openshift/native-observe/dashboards/*.yaml; do
+  key="$(yq -r '.data | keys | .[0]' "${file}")"
+  yq -r ".data[\"${key}\"]" "${file}" | jq empty
+done
+----
+
+Validate the manifest bundle:
+
+[source,bash]
+----
+oc kustomize openshift/native-observe >/tmp/redis-enterprise-native-observe.yaml
+yq eval 'true' /tmp/redis-enterprise-native-observe.yaml >/dev/null
+----
+
+If `promtool` is installed, validate the original alert rule source:
+
+[source,bash]
+----
+promtool check rules prometheus_v2/rules/alerts.yml
+----
+
+On a connected OpenShift cluster, run a server-side dry run:
+
+[source,bash]
+----
+oc apply --dry-run=server -f openshift/native-observe/dashboards/
+
+REDIS_NS="${REDIS_NS}" yq eval '.metadata.namespace = env(REDIS_NS)' \
+  openshift/native-observe/redis-enterprise-servicemonitor.yaml | oc apply --dry-run=server -f -
+
+REDIS_NS="${REDIS_NS}" yq eval '.metadata.namespace = env(REDIS_NS)' \
+  openshift/native-observe/redis-enterprise-prometheusrule.yaml | oc apply --dry-run=server -f -
+----
+
+== Troubleshooting
+
+=== Dashboards Do Not Appear
+
+Check that the dashboard `ConfigMap` resources are in `openshift-config-managed` and have the required label:
+
+[source,bash]
+----
+oc -n openshift-config-managed get cm -l console.openshift.io/dashboard=true
+----
+
+Refresh the web console after applying the `ConfigMap` resources.
+
+=== Dashboards Appear but Show No Data
+
+Check these first:
+
+* The Redis Enterprise metrics service has the `redis.io/service=prom-metrics` label
+* The service port selected by the `ServiceMonitor` is named `prometheus`
+* User workload monitoring is enabled
+* `redis_server_up{namespace="<redis-namespace>"}` returns data in Observe -> Metrics
+* The dashboard `namespace` variable is set to the Redis Enterprise namespace
+
+=== Alerts Do Not Appear
+
+Check that the `PrometheusRule` was created in the Redis Enterprise namespace:
+
+[source,bash]
+----
+oc -n "${REDIS_NS}" get prometheusrule redis-enterprise-observe-alerts
+----
+
+Then check Observe -> Alerting -> Alerting rules for the Redis Enterprise rule groups.
+
+== Next Steps
+
+* Use xref:platforms/prometheus.adoc[Prometheus Integration] for additional scrape examples
+* Use xref:platforms/grafana.adoc[Grafana Integration] if you need full Grafana dashboard fidelity
+* Use xref:guides/openshift-prometheus-grafana.adoc[OpenShift Deployment: Prometheus and Grafana] if you prefer a standalone observability stack in OpenShift

--- a/openshift/native-observe/README.md
+++ b/openshift/native-observe/README.md
@@ -1,0 +1,20 @@
+# Redis Enterprise Native OpenShift Observe
+
+This directory contains example manifests for showing Redis Enterprise metrics in OpenShift's native Observe UI.
+
+Contents:
+
+- `redis-enterprise-servicemonitor.yaml`: Scrapes an in-cluster Redis Enterprise metrics service on `https://<service>:8070/v2`.
+- `redis-enterprise-prometheusrule.yaml`: Wraps the Redis Enterprise Prometheus alert rules for OpenShift user workload monitoring.
+- `dashboards/*.yaml`: Legacy OpenShift dashboard `ConfigMap` resources for Observe -> Dashboards.
+- `kustomization.yaml`: Builds the complete manifest set with `oc kustomize`.
+- `RUNBOOK.md`: Customer-facing deployment runbook for an existing Redis Enterprise active-active installation.
+
+Defaults:
+
+- Redis Enterprise namespace: `redis-enterprise`
+- Metrics service selector: `redis.io/service=prom-metrics`
+- Metrics service port name: `prometheus`
+- Dashboard namespace: `openshift-config-managed`
+
+See `docs/modules/ROOT/pages/guides/openshift-native-observe-dashboards.adoc` for the full installation guide.

--- a/openshift/native-observe/RUNBOOK.md
+++ b/openshift/native-observe/RUNBOOK.md
@@ -1,0 +1,299 @@
+# Runbook: Redis Enterprise Dashboards in OpenShift Observe
+
+This runbook deploys Redis Enterprise observability into OpenShift's native **Observe** UI for an existing Redis Enterprise active-active installation.
+
+It assumes Redis Enterprise is already installed, healthy, and exposing operator-created Prometheus metrics services in two namespaces:
+
+- `ns-a` with metrics service `rec-a-prom`
+- `ns-b` with metrics service `rec-b-prom`
+
+The runbook does not deploy Redis Enterprise, Grafana, or a standalone Prometheus stack.
+
+## What This Deploys
+
+- OpenShift user workload monitoring, if it is not already enabled
+- One `ServiceMonitor` in each Redis Enterprise namespace
+- One `PrometheusRule` in each Redis Enterprise namespace
+- Thirteen Redis Enterprise dashboard `ConfigMap` resources in `openshift-config-managed`
+
+The dashboards appear in the OpenShift console under **Observe -> Dashboards**.
+
+## Prerequisites
+
+- `oc` is installed and authenticated to the target cluster.
+- The current user can administer cluster monitoring.
+- The current user can create `ServiceMonitor` and `PrometheusRule` resources in `ns-a` and `ns-b`.
+- The current user can create `ConfigMap` resources in `openshift-config-managed`.
+- The Redis Enterprise metrics services expose HTTPS metrics on port `8070`, path `/v2`.
+
+Run all commands from the repository root:
+
+```bash
+cd /path/to/redis-enterprise-observability
+```
+
+## 1. Set Deployment Variables
+
+```bash
+export REDIS_A_NS=ns-a
+export REDIS_B_NS=ns-b
+export REDIS_A_METRICS_SERVICE=rec-a-prom
+export REDIS_B_METRICS_SERVICE=rec-b-prom
+```
+
+## 2. Confirm Redis Enterprise Metrics Services
+
+```bash
+oc -n "${REDIS_A_NS}" get svc "${REDIS_A_METRICS_SERVICE}" -o wide
+oc -n "${REDIS_B_NS}" get svc "${REDIS_B_METRICS_SERVICE}" -o wide
+
+oc -n "${REDIS_A_NS}" get endpoints "${REDIS_A_METRICS_SERVICE}" -o wide
+oc -n "${REDIS_B_NS}" get endpoints "${REDIS_B_METRICS_SERVICE}" -o wide
+```
+
+Confirm that each service has:
+
+- Label `redis.io/service=prom-metrics`
+- A port named `prometheus`
+- Port `8070`
+- At least one endpoint
+
+```bash
+oc -n "${REDIS_A_NS}" get svc "${REDIS_A_METRICS_SERVICE}" \
+  -o jsonpath='{.metadata.labels.redis\.io/service}{"\n"}{.spec.ports[?(@.port==8070)].name}{"\n"}'
+
+oc -n "${REDIS_B_NS}" get svc "${REDIS_B_METRICS_SERVICE}" \
+  -o jsonpath='{.metadata.labels.redis\.io/service}{"\n"}{.spec.ports[?(@.port==8070)].name}{"\n"}'
+```
+
+Expected output for each service:
+
+```text
+prom-metrics
+prometheus
+```
+
+## 3. Confirm the Redis `/v2` Metrics Endpoint
+
+Use an existing Redis Enterprise pod to test the metrics service:
+
+```bash
+oc -n "${REDIS_A_NS}" exec rec-a-0 -c redis-enterprise-node -- \
+  sh -lc "curl -sk https://${REDIS_A_METRICS_SERVICE}.${REDIS_A_NS}.svc:8070/v2 | grep -m 5 '^redis_server_up\|^node_metrics_up\|^endpoint_client_connections'"
+
+oc -n "${REDIS_B_NS}" exec rec-b-0 -c redis-enterprise-node -- \
+  sh -lc "curl -sk https://${REDIS_B_METRICS_SERVICE}.${REDIS_B_NS}.svc:8070/v2 | grep -m 5 '^redis_server_up\|^node_metrics_up\|^endpoint_client_connections'"
+```
+
+Each command should print Redis Enterprise metrics.
+
+## 4. Enable User Workload Monitoring
+
+Skip this step only if user workload monitoring is already enabled.
+
+```bash
+cat <<'EOF' | oc apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+EOF
+```
+
+Wait for the monitoring stack:
+
+```bash
+oc -n openshift-user-workload-monitoring rollout status statefulset/prometheus-user-workload --timeout=300s
+oc -n openshift-user-workload-monitoring rollout status statefulset/thanos-ruler-user-workload --timeout=300s
+oc -n openshift-user-workload-monitoring get pods
+```
+
+Expected result:
+
+- `prometheus-user-workload-0` and `prometheus-user-workload-1` are running.
+- `thanos-ruler-user-workload-0` and `thanos-ruler-user-workload-1` are running.
+
+## 5. Server-Side Dry Run
+
+```bash
+NS="${REDIS_A_NS}" yq eval '.metadata.namespace = env(NS)' \
+  openshift/native-observe/redis-enterprise-servicemonitor.yaml | oc apply --dry-run=server -f -
+
+NS="${REDIS_B_NS}" yq eval '.metadata.namespace = env(NS)' \
+  openshift/native-observe/redis-enterprise-servicemonitor.yaml | oc apply --dry-run=server -f -
+
+NS="${REDIS_A_NS}" yq eval '.metadata.namespace = env(NS)' \
+  openshift/native-observe/redis-enterprise-prometheusrule.yaml | oc apply --dry-run=server -f -
+
+NS="${REDIS_B_NS}" yq eval '.metadata.namespace = env(NS)' \
+  openshift/native-observe/redis-enterprise-prometheusrule.yaml | oc apply --dry-run=server -f -
+
+oc apply --dry-run=server -f openshift/native-observe/dashboards/
+```
+
+All commands should report `created (server dry run)` or `configured (server dry run)`.
+
+## 6. Apply Redis Enterprise Monitoring Resources
+
+```bash
+NS="${REDIS_A_NS}" yq eval '.metadata.namespace = env(NS)' \
+  openshift/native-observe/redis-enterprise-servicemonitor.yaml | oc apply -f -
+
+NS="${REDIS_B_NS}" yq eval '.metadata.namespace = env(NS)' \
+  openshift/native-observe/redis-enterprise-servicemonitor.yaml | oc apply -f -
+
+NS="${REDIS_A_NS}" yq eval '.metadata.namespace = env(NS)' \
+  openshift/native-observe/redis-enterprise-prometheusrule.yaml | oc apply -f -
+
+NS="${REDIS_B_NS}" yq eval '.metadata.namespace = env(NS)' \
+  openshift/native-observe/redis-enterprise-prometheusrule.yaml | oc apply -f -
+```
+
+Confirm the resources:
+
+```bash
+oc -n "${REDIS_A_NS}" get servicemonitor redis-enterprise-observe
+oc -n "${REDIS_B_NS}" get servicemonitor redis-enterprise-observe
+oc -n "${REDIS_A_NS}" get prometheusrule redis-enterprise-observe-alerts
+oc -n "${REDIS_B_NS}" get prometheusrule redis-enterprise-observe-alerts
+```
+
+## 7. Apply Native Observe Dashboards
+
+```bash
+oc apply -f openshift/native-observe/dashboards/
+```
+
+Confirm that thirteen dashboard `ConfigMap` resources were created:
+
+```bash
+oc -n openshift-config-managed get cm \
+  -l app.kubernetes.io/name=redis-enterprise-observe \
+  --sort-by=.metadata.name
+```
+
+## 8. Verify Metrics in OpenShift's Aggregate Query Path
+
+Wait at least one scrape interval:
+
+```bash
+sleep 40
+```
+
+Query through the OpenShift Thanos querier. This is the same aggregate metrics path used by the OpenShift console.
+
+```bash
+TOKEN="$(oc whoami -t)"
+
+oc -n openshift-user-workload-monitoring exec prometheus-user-workload-0 -c prometheus -- \
+  sh -c "wget --no-check-certificate --header=\"Authorization: Bearer ${TOKEN}\" -qO- \
+  'https://thanos-querier.openshift-monitoring.svc:9091/api/v1/query?query=up%7Bnamespace%3D%22ns-a%22%7D'"
+
+oc -n openshift-user-workload-monitoring exec prometheus-user-workload-0 -c prometheus -- \
+  sh -c "wget --no-check-certificate --header=\"Authorization: Bearer ${TOKEN}\" -qO- \
+  'https://thanos-querier.openshift-monitoring.svc:9091/api/v1/query?query=up%7Bnamespace%3D%22ns-b%22%7D'"
+```
+
+Both queries should return a result with value `1`.
+
+Run representative dashboard metric checks:
+
+```bash
+TOKEN="$(oc whoami -t)"
+
+oc -n openshift-user-workload-monitoring exec prometheus-user-workload-0 -c prometheus -- sh -c '
+base=https://thanos-querier.openshift-monitoring.svc:9091/api/v1/query
+for q in \
+  "count(redis_server_up{namespace=\"ns-a\"})" \
+  "count(redis_server_up{namespace=\"ns-b\"})" \
+  "sum(redis_server_used_memory{namespace=\"ns-a\",cluster=\"rec-a.ns-a.svc.cluster.local\"})" \
+  "sum(redis_server_used_memory{namespace=\"ns-b\",cluster=\"rec-b.ns-b.svc.cluster.local\"})" \
+  "sum(endpoint_client_connections{namespace=\"ns-a\"})" \
+  "sum(endpoint_client_connections{namespace=\"ns-b\"})" \
+  "count(node_metrics_up{namespace=\"ns-a\"})" \
+  "count(node_metrics_up{namespace=\"ns-b\"})"; do
+  enc=$(printf "%s" "$q" | sed "s/{/%7B/g;s/}/%7D/g;s/\"/%22/g;s/ /%20/g;s/=/%3D/g;s/,/%2C/g;s/+/%2B/g")
+  printf "\nQUERY %s\n" "$q"
+  wget --no-check-certificate --header="Authorization: Bearer '"${TOKEN}"'" -qO- "$base?query=$enc"
+  printf "\n"
+done
+'
+```
+
+Expected results:
+
+- `count(redis_server_up{namespace="ns-a"})` returns a nonzero value.
+- `count(redis_server_up{namespace="ns-b"})` returns a nonzero value.
+- Memory, connection, and node checks return values for both namespaces.
+
+## 9. Verify Alert Rules
+
+Check that Thanos Ruler loaded the rule files:
+
+```bash
+oc -n openshift-user-workload-monitoring logs thanos-ruler-user-workload-0 -c thanos-ruler --tail=200 | grep 'reload rule files'
+oc -n openshift-user-workload-monitoring logs thanos-ruler-user-workload-1 -c thanos-ruler --tail=200 | grep 'reload rule files'
+```
+
+Expected result:
+
+```text
+reload rule files numFiles=2
+```
+
+PromQL informational warnings about metric names not ending in `_total`, `_sum`, `_count`, or `_bucket` can appear for existing Redis Enterprise alert expressions. Those warnings do not indicate a parse failure.
+
+## 10. Verify Dashboards in the Console
+
+Open the OpenShift console and go to:
+
+```text
+Observe -> Dashboards
+```
+
+Confirm that these dashboards are listed:
+
+- Redis Enterprise / Basic / Cluster Status Dashboard
+- Redis Enterprise / Basic / Database Status Dashboard
+- Redis Enterprise / Basic / Node Dashboard
+- Redis Enterprise / Basic / Shard Dashboard
+- Redis Enterprise / Basic / Active-Active
+- Redis Enterprise / Basic / Synchronization (Classic)
+- Redis Enterprise / Ops / Cluster Dashboard
+- Redis Enterprise / Ops / Database Dashboard
+- Redis Enterprise / Ops / Node Dashboard
+- Redis Enterprise / Ops / Shard dashboard
+- Redis Enterprise / Ops / Latency Dashboard
+- Redis Enterprise / Ops / Active-Active Lag
+- Redis Enterprise / Ops / RediSearch QPS dashboard
+
+For each dashboard:
+
+1. Select `ns-a` or `ns-b` in the `namespace` variable.
+2. Select the corresponding Redis Enterprise cluster.
+3. Select database, node, shard, or CRDT variables where present.
+4. Confirm panels render data.
+
+## Rollback
+
+Remove the Redis Enterprise Observe resources:
+
+```bash
+oc -n "${REDIS_A_NS}" delete servicemonitor redis-enterprise-observe --ignore-not-found
+oc -n "${REDIS_B_NS}" delete servicemonitor redis-enterprise-observe --ignore-not-found
+oc -n "${REDIS_A_NS}" delete prometheusrule redis-enterprise-observe-alerts --ignore-not-found
+oc -n "${REDIS_B_NS}" delete prometheusrule redis-enterprise-observe-alerts --ignore-not-found
+oc delete -f openshift/native-observe/dashboards/ --ignore-not-found
+```
+
+Do not disable user workload monitoring unless no other workloads depend on it.
+
+If this runbook was the only reason user workload monitoring was enabled, remove it with care:
+
+```bash
+oc -n openshift-monitoring delete cm cluster-monitoring-config
+```

--- a/openshift/native-observe/dashboards/redis-enterprise-basic-active-active.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-basic-active-active.yaml
@@ -386,7 +386,7 @@ data:
               "tableColumn": "",
               "targets": [
                 {
-                  "expr": "bdb_crdt_syncer_pending_local_writes_max",
+                  "expr": "bdb_crdt_syncer_pending_local_writes_max{namespace=\"$namespace\", cluster=\"$cluster\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "__auto",

--- a/openshift/native-observe/dashboards/redis-enterprise-basic-active-active.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-basic-active-active.yaml
@@ -59,7 +59,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (cluster) (rate(database_syncer_ingress_bytes{namespace=\"$namespace\", syncer_type=\"crdt\", cluster=\"$cluster\"}[1m]))",
+                  "expr": "sum by (cluster) (rate(database_syncer_ingress_bytes{namespace=\"$namespace\", syncer_type=\"crdt\", cluster=\"$cluster\"}[$aggregation]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{cluster}}",
@@ -288,7 +288,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "rate(database_syncer_ingress_bytes_decompressed{namespace=\"$namespace\", cluster=\"$cluster\"}[1m])",
+                  "expr": "rate(database_syncer_ingress_bytes_decompressed{namespace=\"$namespace\", cluster=\"$cluster\"}[$aggregation])",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{cluster}}",

--- a/openshift/native-observe/dashboards/redis-enterprise-basic-active-active.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-basic-active-active.yaml
@@ -1,0 +1,836 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-enterprise-basic-active-active
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+data:
+  redis-enterprise-basic-active-active.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "links": [],
+      "refresh": "30s",
+      "rows": [
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 1,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (cluster) (rate(database_syncer_ingress_bytes{namespace=\"$namespace\", syncer_type=\"crdt\", cluster=\"$cluster\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{cluster}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "CRDT Ingress",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "bytes",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 2,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "redis_server_crdt_raw_dbsize{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "__auto",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "CRDT Raw DB Size",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "ms",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 3,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "redis_server_crdt_peer_lag{namespace=\"$namespace\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "__auto",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "CRDT Lag Time",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 4,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(database_syncer_ingress_bytes_decompressed{namespace=\"$namespace\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{cluster}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "CRDT Ingress (Decompressed)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 5,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "bdb_crdt_syncer_pending_local_writes_max",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "__auto",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "CRDT Max Pending Writes",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "bytes",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 6,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "redis_server_crdt_backlog_histlen{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "__auto",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "CRDT Backlog",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 7,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg by(cluster) (database_syncer_lag_ms{namespace=\"$namespace\", syncer_type=\"crdt\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{cluster}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Ingress Sync Lag Time",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ms",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 8,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_crdt_merge_reqs{namespace=\"$namespace\", role=\"slave\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{cluster}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Merge Requests",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ms",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "bytes",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 9,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "redis_server_crdt_gc_collected{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "__auto",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "CRDT Pending GC",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Overview",
+          "titleSize": "h6"
+        }
+      ],
+      "schemaVersion": 14,
+      "style": "light",
+      "tags": [
+        "redis-enterprise",
+        "openshift-observe",
+        "basic"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(redis_server_up, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\"}, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "1m",
+            "current": {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "aggregation",
+            "options": [],
+            "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "utc",
+      "title": "Redis Enterprise / Basic / Active-Active",
+      "uid": "re-observe-basic-active-active",
+      "version": 1
+    }

--- a/openshift/native-observe/dashboards/redis-enterprise-basic-cluster-status.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-basic-cluster-status.yaml
@@ -228,7 +228,7 @@ data:
               "tableColumn": "",
               "targets": [
                 {
-                  "expr": "(sum by (cluster) (irate (endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\"}[1m]))) + (sum by (cluster) (irate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\"}[1m]))) + (sum by(cluster) (irate (endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\"}[1m])))",
+                  "expr": "(sum by (cluster) (irate (endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\"}[$aggregation]))) + (sum by (cluster) (irate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\"}[$aggregation]))) + (sum by(cluster) (irate (endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\"}[$aggregation])))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "__auto",
@@ -315,7 +315,7 @@ data:
               "tableColumn": "",
               "targets": [
                 {
-                  "expr": "(sum by (cluster, db)(irate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]))  + sum by(cluster, db) (irate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]) ) + sum by (cluster, db) (irate(endpoint_other_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]))) / ((sum by (cluster, db) (irate(endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by(cluster, db)(irate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by(cluster, db)(irate(endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m])))) / 1000",
+                  "expr": "(sum by (cluster, db)(irate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$aggregation]))  + sum by(cluster, db) (irate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$aggregation]) ) + sum by (cluster, db) (irate(endpoint_other_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$aggregation]))) / ((sum by (cluster, db) (irate(endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$aggregation]))) + (sum by(cluster, db)(irate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$aggregation]))) + (sum by(cluster, db)(irate(endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$aggregation])))) / 1000",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "__auto",
@@ -390,7 +390,7 @@ data:
               "tableColumn": "",
               "targets": [
                 {
-                  "expr": "sum by(cluster, db)(irate(endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]) + irate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]) + irate(endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
+                  "expr": "sum by(cluster, db)(irate(endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$aggregation]) + irate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$aggregation]) + irate(endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$aggregation]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "A",
@@ -465,7 +465,7 @@ data:
               "tableColumn": "",
               "targets": [
                 {
-                  "expr": "sum by(cluster) (irate(redis_server_expired_keys{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\"}[1m]))",
+                  "expr": "sum by(cluster) (irate(redis_server_expired_keys{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\"}[$aggregation]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "A",

--- a/openshift/native-observe/dashboards/redis-enterprise-basic-cluster-status.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-basic-cluster-status.yaml
@@ -1,0 +1,781 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-enterprise-basic-cluster-status
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+data:
+  redis-enterprise-basic-cluster-status.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "links": [],
+      "refresh": "30s",
+      "rows": [
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 1,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 4,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "scalar(count(count by (db) (endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\"})))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "count",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Database Count",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "bytes",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 2,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 4,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum(redis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "__auto",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Used Memory",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "ops",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 3,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 4,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "(sum by (cluster) (irate (endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\"}[1m]))) + (sum by (cluster) (irate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\"}[1m]))) + (sum by(cluster) (irate (endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\"}[1m])))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "__auto",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Throughput",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Summary",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "ms",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 4,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "(sum by (cluster, db)(irate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]))  + sum by(cluster, db) (irate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]) ) + sum by (cluster, db) (irate(endpoint_other_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]))) / ((sum by (cluster, db) (irate(endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by(cluster, db)(irate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by(cluster, db)(irate(endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m])))) / 1000",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "__auto",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Latency",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "ops",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 5,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum by(cluster, db)(irate(endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]) + irate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]) + irate(endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 14400
+                }
+              ],
+              "thresholds": "",
+              "title": "Total Operations",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "ops",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 6,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum by(cluster) (irate(redis_server_expired_keys{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 14400
+                }
+              ],
+              "thresholds": "",
+              "title": "Expiration",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 7,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "scalar(sum by(cluster, db)(redis_server_db_keys{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"}))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 14400
+                }
+              ],
+              "thresholds": "",
+              "title": "Key Count",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 8,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "scalar(sum by(cluster, db)(endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} - endpoint_client_disconnections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 14400
+                }
+              ],
+              "thresholds": "",
+              "title": "Connection Count",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "$db",
+          "titleSize": "h6"
+        }
+      ],
+      "schemaVersion": 14,
+      "style": "light",
+      "tags": [
+        "redis-enterprise",
+        "openshift-observe",
+        "basic"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(redis_server_up, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\"}, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "1m",
+            "current": {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "aggregation",
+            "options": [],
+            "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "db",
+            "options": [],
+            "query": "label_values(endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\"},db)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "utc",
+      "title": "Redis Enterprise / Basic / Cluster Status Dashboard",
+      "uid": "re-observe-basic-cluster-status",
+      "version": 1
+    }

--- a/openshift/native-observe/dashboards/redis-enterprise-basic-database-status.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-basic-database-status.yaml
@@ -1,0 +1,951 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-enterprise-basic-database-status
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+data:
+  redis-enterprise-basic-database-status.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "links": [],
+      "refresh": "30s",
+      "rows": [
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 1,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(sum(irate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", db=\"$db\"}[1m]))/sum(irate(endpoint_read_requests{namespace=\"$namespace\", db=\"$db\"}[1m])))/1000000",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Read",
+                  "refId": "A",
+                  "step": 2400
+                },
+                {
+                  "expr": "(sum(irate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", db=\"$db\"}[1m]))/sum(irate(endpoint_write_requests{namespace=\"$namespace\", db=\"$db\"}[1m])))/1000000",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Write",
+                  "refId": "B",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Latency",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "percent",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 2,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "(sum by (db,cluster) (redis_server_used_memory{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}) / avg by (db,cluster) (db_memory_limit_bytes{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"})) / avg by (db,cluster) (db_replication_factor{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "__auto",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Memory Usage",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "ops",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 3,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum by (db, cluster) (irate(endpoint_read_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]) + irate(endpoint_write_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]) + irate(endpoint_other_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "__auto",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Total Operations",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 4,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db, cluster) (irate(endpoint_read_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "read",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by (db, cluster) (irate(endpoint_write_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "write",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by(db, cluster) (irate(endpoint_other_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "other",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Operations",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 5,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "scalar(sum by (db, cluster) (redis_server_db_keys{namespace=\"$namespace\", role=\"master\", db=\"$db\", cluster=\"$cluster\"}))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 14400
+                }
+              ],
+              "thresholds": "",
+              "title": "Key Count",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "ops",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 6,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum by (db, cluster) (irate(redis_server_expired_keys{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Expired Keys",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Expired Keys",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 7,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "scalar(sum by (db, cluster) (endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} - endpoint_client_disconnections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 14400
+                }
+              ],
+              "thresholds": "",
+              "title": "Connection Count",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "ops",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 8,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "(sum by (db, cluster) (irate(redis_server_keyspace_read_misses{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by (db, cluster) (irate(redis_server_keyspace_write_misses{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m])))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "__auto",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Total Misses",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "percent",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 9,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum by(db, cluster) (irate(namedprocess_namegroup_thread_cpu_seconds_total{namespace=\"$namespace\", mode=\"system\", threadname=~\"redis-server.*\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "__auto",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "System CPU",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "percent",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 10,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum by(db, cluster) (irate(namedprocess_namegroup_thread_cpu_seconds_total{namespace=\"$namespace\", mode=\"user\", threadname=~\"redis-server.*\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "__auto",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "User CPU",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Overview",
+          "titleSize": "h6"
+        }
+      ],
+      "schemaVersion": 14,
+      "style": "light",
+      "tags": [
+        "redis-enterprise",
+        "openshift-observe",
+        "basic"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(redis_server_up, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\"}, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "db",
+            "options": [],
+            "query": "label_values(endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\"},db)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "1m",
+            "current": {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "aggregation",
+            "options": [],
+            "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "utc",
+      "title": "Redis Enterprise / Basic / Database Status Dashboard",
+      "uid": "re-observe-basic-database-status",
+      "version": 1
+    }

--- a/openshift/native-observe/dashboards/redis-enterprise-basic-database-status.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-basic-database-status.yaml
@@ -59,7 +59,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "(sum(irate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", db=\"$db\"}[1m]))/sum(irate(endpoint_read_requests{namespace=\"$namespace\", db=\"$db\"}[1m])))/1000000",
+                  "expr": "(sum(irate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]))/sum(irate(endpoint_read_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m])))/1000000",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "Read",
@@ -67,7 +67,7 @@ data:
                   "step": 2400
                 },
                 {
-                  "expr": "(sum(irate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", db=\"$db\"}[1m]))/sum(irate(endpoint_write_requests{namespace=\"$namespace\", db=\"$db\"}[1m])))/1000000",
+                  "expr": "(sum(irate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]))/sum(irate(endpoint_write_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m])))/1000000",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "Write",

--- a/openshift/native-observe/dashboards/redis-enterprise-basic-database-status.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-basic-database-status.yaml
@@ -59,7 +59,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "(sum(irate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]))/sum(irate(endpoint_read_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m])))/1000000",
+                  "expr": "(sum(irate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[$aggregation]))/sum(irate(endpoint_read_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[$aggregation])))/1000000",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "Read",
@@ -67,7 +67,7 @@ data:
                   "step": 2400
                 },
                 {
-                  "expr": "(sum(irate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]))/sum(irate(endpoint_write_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m])))/1000000",
+                  "expr": "(sum(irate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[$aggregation]))/sum(irate(endpoint_write_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[$aggregation])))/1000000",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "Write",
@@ -240,7 +240,7 @@ data:
               "tableColumn": "",
               "targets": [
                 {
-                  "expr": "sum by (db, cluster) (irate(endpoint_read_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]) + irate(endpoint_write_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]) + irate(endpoint_other_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
+                  "expr": "sum by (db, cluster) (irate(endpoint_read_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[$aggregation]) + irate(endpoint_write_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[$aggregation]) + irate(endpoint_other_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[$aggregation]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "__auto",
@@ -296,7 +296,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (db, cluster) (irate(endpoint_read_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
+                  "expr": "sum by (db, cluster) (irate(endpoint_read_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[$aggregation]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "read",
@@ -304,7 +304,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "sum by (db, cluster) (irate(endpoint_write_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
+                  "expr": "sum by (db, cluster) (irate(endpoint_write_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[$aggregation]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "write",
@@ -312,7 +312,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "sum by(db, cluster) (irate(endpoint_other_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
+                  "expr": "sum by(db, cluster) (irate(endpoint_other_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[$aggregation]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "other",
@@ -485,7 +485,7 @@ data:
               "tableColumn": "",
               "targets": [
                 {
-                  "expr": "sum by (db, cluster) (irate(redis_server_expired_keys{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
+                  "expr": "sum by (db, cluster) (irate(redis_server_expired_keys{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"}[$aggregation]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "Expired Keys",
@@ -635,7 +635,7 @@ data:
               "tableColumn": "",
               "targets": [
                 {
-                  "expr": "(sum by (db, cluster) (irate(redis_server_keyspace_read_misses{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m]))) + (sum by (db, cluster) (irate(redis_server_keyspace_write_misses{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m])))",
+                  "expr": "(sum by (db, cluster) (irate(redis_server_keyspace_read_misses{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"}[$aggregation]))) + (sum by (db, cluster) (irate(redis_server_keyspace_write_misses{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"}[$aggregation])))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "__auto",
@@ -710,7 +710,7 @@ data:
               "tableColumn": "",
               "targets": [
                 {
-                  "expr": "sum by(db, cluster) (irate(namedprocess_namegroup_thread_cpu_seconds_total{namespace=\"$namespace\", mode=\"system\", threadname=~\"redis-server.*\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
+                  "expr": "sum by(db, cluster) (irate(namedprocess_namegroup_thread_cpu_seconds_total{namespace=\"$namespace\", mode=\"system\", threadname=~\"redis-server.*\", cluster=\"$cluster\", db=\"$db\"}[$aggregation]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "__auto",
@@ -785,7 +785,7 @@ data:
               "tableColumn": "",
               "targets": [
                 {
-                  "expr": "sum by(db, cluster) (irate(namedprocess_namegroup_thread_cpu_seconds_total{namespace=\"$namespace\", mode=\"user\", threadname=~\"redis-server.*\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
+                  "expr": "sum by(db, cluster) (irate(namedprocess_namegroup_thread_cpu_seconds_total{namespace=\"$namespace\", mode=\"user\", threadname=~\"redis-server.*\", db=\"$db\", cluster=\"$cluster\"}[$aggregation]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "__auto",

--- a/openshift/native-observe/dashboards/redis-enterprise-basic-database-status.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-basic-database-status.yaml
@@ -121,7 +121,7 @@ data:
               ],
               "datasource": null,
               "decimals": null,
-              "format": "percent",
+              "format": "percentunit",
               "gauge": {
                 "maxValue": 100,
                 "minValue": 0,
@@ -666,7 +666,7 @@ data:
               ],
               "datasource": null,
               "decimals": null,
-              "format": "percent",
+              "format": "percentunit",
               "gauge": {
                 "maxValue": 100,
                 "minValue": 0,
@@ -741,7 +741,7 @@ data:
               ],
               "datasource": null,
               "decimals": null,
-              "format": "percent",
+              "format": "percentunit",
               "gauge": {
                 "maxValue": 100,
                 "minValue": 0,

--- a/openshift/native-observe/dashboards/redis-enterprise-basic-node.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-basic-node.yaml
@@ -1,0 +1,597 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-enterprise-basic-node
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+data:
+  redis-enterprise-basic-node.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "links": [],
+      "refresh": "30s",
+      "rows": [
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 1,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(avg by(node) (irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"system\", cluster=\"$cluster\", node=\"$node\"}[1m]))) + (avg by(node) (irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"user\", cluster=\"$cluster\", node=\"$node\"}[1m])))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "user+system",
+                  "refId": "B",
+                  "step": 600
+                },
+                {
+                  "expr": "1- (avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"idle\",cluster=\"$cluster\", node=\"$node\"}[1m]))) - (avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"system\",cluster=\"$cluster\", node=\"$node\"}[1m]))) - (avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"user\",cluster=\"$cluster\", node=\"$node\"}[1m]))) unless (avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"nice\",cluster=\"$cluster\", node=\"$node\"}[1m])))",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "other",
+                  "refId": "A",
+                  "step": 300
+                },
+                {
+                  "expr": "avg by(node)(irate(dmcproxy_process_cpu_user_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "dmcproxy (100% = 1 core)",
+                  "refId": "G",
+                  "step": 600
+                },
+                {
+                  "expr": "avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=~\"system|user\", cluster=\"$cluster\", node=\"$node\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shards (100% = 1 core)",
+                  "refId": "H",
+                  "step": 600
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "CPU Usage on Node",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 2,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by(node)(irate(node_network_receive_bytes_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Ingress for node {{node}}",
+                  "refId": "A",
+                  "step": 1200
+                },
+                {
+                  "expr": "sum by(node)(irate(node_network_transmit_bytes_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "egress for node {{node}}",
+                  "refId": "B",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Node Traffic",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 3,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg(redis_server_allocator_active{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"} / redis_server_allocator_allocated{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"}) - 1",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "active / allocated (defraggable)",
+                  "refId": "A",
+                  "step": 1200
+                },
+                {
+                  "expr": "avg(redis_server_allocator_resident{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"} / redis_server_allocator_active{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"}) - 1",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "resident / active (purgable)",
+                  "refId": "B",
+                  "step": 1200
+                },
+                {
+                  "expr": "sum(redis_server_allocator_active{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"} - redis_server_allocator_allocated{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "active - allocated (defraggable)",
+                  "refId": "C",
+                  "step": 1200
+                },
+                {
+                  "expr": "sum(redis_server_allocator_resident{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"} - redis_server_allocator_active{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "resident - active (purgable)",
+                  "refId": "D",
+                  "step": 1200
+                },
+                {
+                  "expr": "avg(redis_server_active_defrag_running{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"})/100",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "active defrag running",
+                  "refId": "E",
+                  "step": 1200
+                },
+                {
+                  "expr": "sum(namedprocess_namegroup_memory_bytes{namespace=\"$namespace\", memtype=\"resident\", node=\"$node\",cluster=\"$cluster\"}) - sum(redis_server_allocator_resident{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "process rss - allocator rss",
+                  "refId": "F",
+                  "step": 1200
+                },
+                {
+                  "expr": "sum(namedprocess_namegroup_memory_bytes{namespace=\"$namespace\", memtype=\"resident\", node=\"$node\",cluster=\"$cluster\"}) / sum(redis_server_allocator_resident{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "process rss / allocator rss",
+                  "refId": "G",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Fragmentation",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 4,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "topk(10, redis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}, bdb:{{bdb}},  role:{{role}}",
+                  "refId": "A",
+                  "step": 1200
+                },
+                {
+                  "expr": "dmcproxy_process_resident_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "dmcproxy",
+                  "refId": "B",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Top 10 Shards by Used Memory",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Node $node : CPU",
+          "titleSize": "h6"
+        }
+      ],
+      "schemaVersion": 14,
+      "style": "light",
+      "tags": [
+        "redis-enterprise",
+        "openshift-observe",
+        "basic"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(redis_server_up, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\"}, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "node",
+            "options": [],
+            "query": "label_values(node_metrics_up{namespace=\"$namespace\", cluster=\"$cluster\"}, node)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "version",
+            "options": [],
+            "query": "label_values(node_config{namespace=\"$namespace\", cluster=\"$cluster\",node=\"$node\"}, cnm_version)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "1m",
+            "current": {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "aggregation",
+            "options": [],
+            "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "utc",
+      "title": "Redis Enterprise / Basic / Node Dashboard",
+      "uid": "re-observe-basic-node",
+      "version": 1
+    }

--- a/openshift/native-observe/dashboards/redis-enterprise-basic-node.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-basic-node.yaml
@@ -59,7 +59,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "(avg by(node) (irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"system\", cluster=\"$cluster\", node=\"$node\"}[1m]))) + (avg by(node) (irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"user\", cluster=\"$cluster\", node=\"$node\"}[1m])))",
+                  "expr": "(avg by(node) (irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"system\", cluster=\"$cluster\", node=\"$node\"}[$aggregation]))) + (avg by(node) (irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"user\", cluster=\"$cluster\", node=\"$node\"}[$aggregation])))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "user+system",
@@ -67,7 +67,7 @@ data:
                   "step": 600
                 },
                 {
-                  "expr": "1- (avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"idle\",cluster=\"$cluster\", node=\"$node\"}[1m]))) - (avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"system\",cluster=\"$cluster\", node=\"$node\"}[1m]))) - (avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"user\",cluster=\"$cluster\", node=\"$node\"}[1m]))) unless (avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"nice\",cluster=\"$cluster\", node=\"$node\"}[1m])))",
+                  "expr": "1- (avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"idle\",cluster=\"$cluster\", node=\"$node\"}[$aggregation]))) - (avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"system\",cluster=\"$cluster\", node=\"$node\"}[$aggregation]))) - (avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"user\",cluster=\"$cluster\", node=\"$node\"}[$aggregation]))) unless (avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"nice\",cluster=\"$cluster\", node=\"$node\"}[$aggregation])))",
                   "format": "time_series",
                   "intervalFactor": 1,
                   "legendFormat": "other",
@@ -75,7 +75,7 @@ data:
                   "step": 300
                 },
                 {
-                  "expr": "avg by(node)(irate(dmcproxy_process_cpu_user_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[1m]))",
+                  "expr": "avg by(node)(irate(dmcproxy_process_cpu_user_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$aggregation]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "dmcproxy (100% = 1 core)",
@@ -83,7 +83,7 @@ data:
                   "step": 600
                 },
                 {
-                  "expr": "avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=~\"system|user\", cluster=\"$cluster\", node=\"$node\"}[1m]))",
+                  "expr": "avg by(node)(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=~\"system|user\", cluster=\"$cluster\", node=\"$node\"}[$aggregation]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "shards (100% = 1 core)",
@@ -162,7 +162,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by(node)(irate(node_network_receive_bytes_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[1m]))",
+                  "expr": "sum by(node)(irate(node_network_receive_bytes_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$aggregation]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "Ingress for node {{node}}",
@@ -170,7 +170,7 @@ data:
                   "step": 1200
                 },
                 {
-                  "expr": "sum by(node)(irate(node_network_transmit_bytes_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[1m]))",
+                  "expr": "sum by(node)(irate(node_network_transmit_bytes_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$aggregation]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "egress for node {{node}}",

--- a/openshift/native-observe/dashboards/redis-enterprise-basic-shard.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-basic-shard.yaml
@@ -1,0 +1,4001 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-enterprise-basic-shard
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+data:
+  redis-enterprise-basic-shard.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "links": [],
+      "refresh": "30s",
+      "rows": [
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 1,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "scalar(redis_server_connected_clients{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 14400
+                }
+              ],
+              "thresholds": "",
+              "title": "Connection Count",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "$db : shard $shard : Summary",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 2,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_maxmemory{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard {{redis}}",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Max Memory",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 3,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_allocator_allocated{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard {{redis}}",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Allocated Memory",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 4,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_allocator_resident{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard {{redis}}",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Resident Memory",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 5,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_allocator_allocated{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard {{redis}}",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Process Memory",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 6,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_mem_fragmentation_ratio{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard {{redis}}",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Fragmentation Ratio",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 7,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_mem_aof_buffer{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard {{redis}}",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "AOF Buffer",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 8,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_mem_not_counted_for_evict{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard {{redis}}",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Memory less Eviction",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 9,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_mem_replication_backlog{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard {{redis}}",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Replication Backlog",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "$db : shard $shard : Memory",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 10,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", redis=\"$shard\", mode=\"system\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "System CPU",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", redis=\"$shard\", mode=\"user\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "User CPU",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Process CPU",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 11,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (redis)(rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", mode=~\"system|user\", redis=\"$shard\", cluster=\"$cluster\", db=\"$db\"}[1m])) * 100",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "__auto",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "CPU Usage",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 12,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", redis=\"$shard\", mode=\"system\", cluster=\"$cluster\", db=\"$db\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Main Thread - System",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", redis=\"$shard\", mode=\"user\", cluster=\"$cluster\", db=\"$db\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Main Thread - User",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Main Thread",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "$db : shard $shard : CPU",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 13,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_connected_clients{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"} ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Connections",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 14,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(redis_server_total_commands_processed{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Connected Clients",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Commands Processed",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 15,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(redis_server_total_net_output_bytes{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Egress",
+                  "refId": "A",
+                  "step": 2400
+                },
+                {
+                  "expr": "rate(redis_server_total_net_input_bytes{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Ingress",
+                  "refId": "B",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Ingress/Egress",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "$db : shard $shard : Network",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 16,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(sum by (db) (redis_server_db_keys{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"})) / (count by(db) (redis_server_db_keys{namespace=\"$namespace\", role=\"maste\", cluster=\"$cluster\", db=\"$db\"}))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard:{{redis}}, role: {{role}}, node:{{node}}, slots:{{slots}}",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Keys per Shard",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 17,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_db_keys{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard: {{redis}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total Keys",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 18,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_evicted_keys{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard: {{redis}}",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Evicted Count",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 19,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_expired_keys{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", redis=\"$shard\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard: {{redis}}",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Expired Keys",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "$db : shard $shard : Keys",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 20,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(redis_server_mem_fragmentation_ratio{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"}) / count(redis_server_mem_fragmentation_ratio{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis_mem_fragmentation_ratio",
+                  "refId": "A",
+                  "step": 2400
+                },
+                {
+                  "expr": "sum(redis_server_allocator_active{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"}) / sum(redis_server_allocator_allocated{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Shard allocator fragmentation",
+                  "refId": "B",
+                  "step": 2400
+                },
+                {
+                  "expr": "sum(redis_server_allocator_resident{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"}) / sum(redis_server_allocator_active{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard allocator rss",
+                  "refId": "C",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total Fragmentation",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 21,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_mem_fragmentation_ratio{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\", redis=\"$shard\"} ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard:{{redis}} role:{{role}}",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Shard RSS Fragmentation",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 22,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_allocator_active{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"} - redis_server_allocator_allocated{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard:{{redis}} role:{{role}}",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Shard Allocation Fragmentation (#)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 23,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_allocator_active{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"} / redis_server_allocator_allocated{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", redis=\"$shard\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard:{{redis}} role:{{role}}",
+                  "refId": "A",
+                  "step": 2400
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Shard Allocation Fragmentation (%)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "$db : shard $shard : Cache",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 24,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_used_ram{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Used RAM",
+                  "refId": "A",
+                  "step": 1200
+                },
+                {
+                  "expr": "redis_server_max_ram{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "limit (when low, near used)",
+                  "refId": "B",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Used Memory(ROF) for db",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 25,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg by(db)((redis_server_ram_fetch_hit_ratio_ram{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"} + redis_server_ram_write_hit_ratio_ram{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"} + redis_server_ram_del_hit_ratio_ram{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}) / (redis_server_ram_fetch_hit_ratio_flash{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"} + redis_server_ram_write_hit_ratio_flash{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"} + redis_server_ram_del_hit_ratio_flash{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"} + redis_server_ram_fetch_hit_ratio_ram{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"} + redis_server_ram_write_hit_ratio_ram{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"} + redis_server_ram_del_hit_ratio_ram{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"})) > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "DB ram hit ratio",
+                  "refId": "A",
+                  "step": 1200
+                },
+                {
+                  "expr": "(avg by (db)(redis_server_ram_fetch_hit_ratio_ram{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} / (redis_server_ram_fetch_hit_ratio_flash{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} + redis_server_ram_fetch_hit_ratio_ram{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}))) > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "read hit ratio",
+                  "refId": "B",
+                  "step": 1200
+                },
+                {
+                  "expr": "avg by(db) (redis_server_ram_write_hit_ratio_ram{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}/(redis_server_ram_write_hit_ratio_flash{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}+redis_server_ram_write_hit_ratio_ram{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})) > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "write hit ratio",
+                  "refId": "C",
+                  "step": 1200
+                },
+                {
+                  "expr": "avg by(db) (redis_server_ram_del_hit_ratio_ram{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}/(redis_server_ram_del_hit_ratio_flash{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}+redis_server_ram_del_hit_ratio_ram{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})) > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "del hit ratio",
+                  "refId": "D",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB ram hit ratio",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 26,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg(delta(redis_server_big_io_ratio_redis{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\",role=\"master\"}[1m]))/60",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "RAM Ops for Redis",
+                  "refId": "A",
+                  "step": 1200
+                },
+                {
+                  "expr": "avg(delta(redis_server_big_io_ratio_flash{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\",role=\"master\"}[1m]) * -1)/60",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Flash Ops for Redis",
+                  "refId": "B",
+                  "step": 1200
+                },
+                {
+                  "expr": "avg(delta(redis_server_big_user_io_ratio_redis{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\",role=\"master\"}[1m]))/60",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "User RAM Ops for Redis",
+                  "refId": "C",
+                  "step": 1200
+                },
+                {
+                  "expr": "avg(delta(redis_server_big_user_io_ratio_flash{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\",role=\"master\"}[1m]) * -1)/60",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "User Flash Ops for Redis",
+                  "refId": "D",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "RAM:Flash access ratio",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ops",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 27,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "delta(redis_server_big_io_ratio_redis{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"}[1m])/60",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "RAM Ops for Redis {{redis}}",
+                  "refId": "A",
+                  "step": 1200
+                },
+                {
+                  "expr": "delta(redis_server_big_io_ratio_flash{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"}[1m]) / -60",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Flash Ops for Redis {{redis}}",
+                  "refId": "B",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "RAM:Flash access ratio",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ops",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 28,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg by(db)(redis_server_big_io_reads{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Reads",
+                  "refId": "A",
+                  "step": 1200
+                },
+                {
+                  "expr": "avg by(db)(redis_server_big_io_writes{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Writes",
+                  "refId": "B",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Flash IO Banwidth",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 29,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db)(redis_server_big_io_reads{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Reads",
+                  "refId": "A",
+                  "step": 1200
+                },
+                {
+                  "expr": "sum by (db)(redis_server_big_io_writes{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Writes",
+                  "refId": "B",
+                  "step": 1200
+                },
+                {
+                  "expr": "sum by (db)(redis_server_big_io_dels{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Deletes",
+                  "refId": "C",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Flash IOPS",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 30,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(delta(redis_server_wait_busy_key{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\"}[$aggregation]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{$db}}",
+                  "refId": "A",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB sum redis wait busy key / $aggregation",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 31,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(delta(redis_server_blocking_reads{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\"}[$aggregation]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{$db}}",
+                  "refId": "A",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB sum redis blocking reads / $aggregation",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 32,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db)(redis_server_used_disk{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "used",
+                  "refId": "A",
+                  "step": 1200
+                },
+                {
+                  "expr": "sum by(db)(redis_server_used_disk{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\"}) * avg by(db) (redis_server_disk_fragmentation_ratio{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "actual",
+                  "refId": "B",
+                  "step": 1200
+                },
+                {
+                  "expr": "avg by (db)(redis_server_disk_fragmentation_ratio{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "frag ratio",
+                  "refId": "C",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB used flash",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 33,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db)(redis_server_big_inst_avg_io_postponed_clients{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{$db}}",
+                  "refId": "A",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB postponed clients",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 34,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db)(redis_server_big_inst_avg_io_blocked_clients{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Number of blocked clients",
+                  "refId": "A",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB blocked clients",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 35,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db)(redis_server_ram_overhead{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", role=\"master\"})  / sum by(db) (redis_server_used_ram{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\",role=\"master\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total Ratio",
+                  "refId": "B",
+                  "step": 1200
+                },
+                {
+                  "expr": "sum by (db, role)(redis_server_ram_overhead{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"})  / sum by(db,role) (redis_server_max_ram{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db: {{db}} role:{{role}}",
+                  "refId": "C",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB ram overhead",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 36,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by(db)(rate(redis_server_blocking_writes{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "A",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB sum redis blocking writes",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 37,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db)(redis_server_big_inst_avg_read_io_queue{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "A",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB sum redis big inst avg read io queue",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 38,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db)(redis_server_big_inst_avg_write_io_queue{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "A",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB sum redis big inst avg write io queue",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 39,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by(db)(redis_server_bigdb_disk{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", role=\"master\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "objects in flash (sum of all master shards)",
+                  "refId": "A",
+                  "step": 1200
+                },
+                {
+                  "expr": "sum by (db)(redis_server_bigdb_ram{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", role=\"master\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "objects in ram (sum of all master shards)",
+                  "refId": "B",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB objects(values) in FLASH",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 40,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by(db,cluster)(redis_server_bigdb_ram{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", role=\"master\"}) / sum by (db,cluster)(redis_server_db_keys{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\",role=\"master\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "DB % values in RAM (masters)",
+                  "refId": "A",
+                  "step": 1200
+                },
+                {
+                  "expr": "avg((max(redis_server_bigdb_ram{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\",role=\"master\"}) by (redis,db,cluster)) / on (redis,db,cluster) redis_server_db_keys{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\",role=\"master\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "average master shard % values in RAM",
+                  "refId": "C",
+                  "step": 1200
+                },
+                {
+                  "expr": "avg((max(redis_server_bigdb_ram{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\",role=\"slave\"}) by (redis,db,cluster)) / on (redis,db,cluster) redis_server_db_keys{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\",role=\"slave\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "average slave shard % values in RAM",
+                  "refId": "D",
+                  "step": 1200
+                },
+                {
+                  "expr": "topk(1, min((max(redis_server_bigdb_ram{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\",role=\"master\"}) by (redis,db,cluster)) / on (redis,db,cluster) redis_server_db_keys{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\",role=\"master\"}) by (redis) * -1) *-1",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "lowest master shard % values in RAM - redis:{{redis}}",
+                  "refId": "F",
+                  "step": 1200
+                },
+                {
+                  "expr": "topk(1, min((max(redis_server_bigdb_ram{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\",role=\"slave\"}) by (redis,db,cluster)) / on (redis,db,cluster) redis_server_db_keys{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\",role=\"slave\"}) by (redis) * -1) *-1",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "lowest slave shard % values in RAM - redis:{{redis}}",
+                  "refId": "G",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB % values in RAM",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 41,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg(max(redis_server_bigdb_ram{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\",role=\"slave\"}))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "average number of values in ram per slave shard",
+                  "refId": "D",
+                  "step": 1200
+                },
+                {
+                  "expr": "avg(max(redis_server_bigdb_ram{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\",role=\"master\"}))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "average number of values in ram per master shard",
+                  "refId": "E",
+                  "step": 1200
+                },
+                {
+                  "expr": "min by(redis)(redis_server_bigdb_ram{namespace=\"$namespace\", role=\"slave\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "lowest number of values in ram per slave shard - redis:{{redis}}",
+                  "refId": "F",
+                  "step": 1200
+                },
+                {
+                  "expr": "min by(redis)(redis_server_bigdb_ram{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "lowest number of values in ram per master shard  - redis:{{redis}}",
+                  "refId": "G",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Shard objects(values) in RAM",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 42,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_ram_dirty_evictions{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", role=\"master\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "A",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB dirty RAM evictions",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 43,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_ram_clean_evictions{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\", role=\"master\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "A",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB clean RAM evictions",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 44,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(delta(redis_server_rocks_comp_started{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "compactions",
+                  "refId": "A",
+                  "step": 1200
+                },
+                {
+                  "expr": "sum(delta(redis_server_rocks_flush_started{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "flushes",
+                  "refId": "B",
+                  "step": 1200
+                },
+                {
+                  "expr": "sum(delta(redis_server_rocks_flush_writes_slowdown{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[$aggregation]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "slowdowns / $aggregation",
+                  "refId": "C",
+                  "step": 1200
+                },
+                {
+                  "expr": "sum(delta(redis_server_rocks_flush_writes_stop{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[$aggregation]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "stalls / $aggregation",
+                  "refId": "D",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "RocksDB",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "$db : shard $shard : ROF Metrics",
+          "titleSize": "h6"
+        }
+      ],
+      "schemaVersion": 14,
+      "style": "light",
+      "tags": [
+        "redis-enterprise",
+        "openshift-observe",
+        "basic"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(redis_server_up, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\"}, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "newStatus",
+            "options": [],
+            "query": "label_values(redis_server_connected_clients{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}, status)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "db",
+            "options": [],
+            "query": "label_values(endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\"},db)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "shard",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}, redis)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "1m",
+            "current": {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "aggregation",
+            "options": [],
+            "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "utc",
+      "title": "Redis Enterprise / Basic / Shard Dashboard",
+      "uid": "re-observe-basic-shard",
+      "version": 1
+    }

--- a/openshift/native-observe/dashboards/redis-enterprise-basic-synchronization.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-basic-synchronization.yaml
@@ -1,0 +1,4956 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-enterprise-basic-synchronization
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+data:
+  redis-enterprise-basic-synchronization.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "links": [],
+      "refresh": "30s",
+      "rows": [
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 1,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_avg_latency{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "bdb_avg_latency - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "bdb_avg_write_latency{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "bdb_avg_write_latency - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "bdb_avg_read_latency{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "bdb_avg_read_latency - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "bdb_avg_other_latency{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "bdb_avg_other_latency - Replica:{{crdt_replica_id}}",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "max_over_time(bdb_avg_latency_max{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[$aggregation])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "bdb_avg_latency (max over $aggregation) - Replica:{{crdt_replica_id}}",
+                  "refId": "E",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Average database latency",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 2,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "listener_acc_latency{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} / listener_total_started_res{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - listener {{proxy}}  node {{node}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Average database listener latency",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 3,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_used_memory{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "used_memory - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "bdb_memory_limit{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} < bdb_used_memory{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} * 1.5",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "limit (when low, near used) - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Database used memory",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Latency",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 4,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_conns{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - Total",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "listener_conns{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - endpoint {{proxy}} node: {{node}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Database Connections",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 5,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_total_req{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "total requests - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "bdb_other_req{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "other requests - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "bdb_read_req{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "read requests - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "bdb_write_req{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "write requests - Replica:{{crdt_replica_id}}",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "bdb_total_req_max{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "total requests (max) - Replica:{{crdt_replica_id}}",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "max_over_time(bdb_total_req_max{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[$aggregation])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "total requests (max over $aggregation) - Replica:{{crdt_replica_id}}",
+                  "refId": "F",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Requests[total,read,write,other] for database",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ops",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 6,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "- bdb_egress_bytes{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "BDB Egress - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "bdb_ingress_bytes{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "BDB Ingress - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by (crdt_replica_id) (rate(redis_total_net_input_bytes{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", role=\"master\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Master shard Ingress - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "- (sum by (crdt_replica_id) (rate(redis_total_net_output_bytes{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", role=\"master\"}[1m]) - rate(redis_master_repl_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", role=\"master\"}[1m])))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Master shard Egress - Replica:{{crdt_replica_id}}",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by (crdt_replica_id) (rate(redis_master_repl_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", role=\"master\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Master shard replication - Replica:{{crdt_replica_id}}",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by (crdt_replica_id) (rate(redis_repl_touch_bytes{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", role=\"master\"}[1m]))!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Master shard repl touch - Replica:{{crdt_replica_id}}",
+                  "refId": "F",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Database Ingress/Egress",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Network",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 7,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_main_thread_cpu_system{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} + bdb_main_thread_cpu_user{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "main threads (masters) - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "bdb_shard_cpu_system{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} + bdb_shard_cpu_user{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "all threads (masters) - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "bdb_fork_cpu_system{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} + bdb_fork_cpu_user{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "all forks (masters) - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "bdb_main_thread_cpu_system_max{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} + bdb_main_thread_cpu_user_max{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "main threads max (masters) - Replica:{{crdt_replica_id}}",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "bdb_shard_cpu_system_max{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} + bdb_shard_cpu_user_max{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "all threads max (masters) - Replica:{{crdt_replica_id}}",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by (crdt_replica_id) ((delta(redis_process_main_thread_cpu_system_seconds_total{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"}[60s]) + delta(redis_process_main_thread_cpu_user_seconds_total{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"}[60s]))/60)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Slave main threads - Replica:{{crdt_replica_id}}",
+                  "refId": "F",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by (crdt_replica_id) ((delta(redis_process_cpu_system_seconds_total{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"}[60s]) + delta(redis_process_cpu_user_seconds_total{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"}[60s]))/60)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Slave all threads - Replica:{{crdt_replica_id}}",
+                  "refId": "G",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "CPU utilization for database",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 8,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(delta(redis_process_cpu_system_seconds_total{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[60s]) + delta(redis_process_cpu_user_seconds_total{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[60s]))/60*100 or redis_cpu_percent{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - shard: {{redis}} role: {{role}} node:{{node}}, slots:{{slots}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "CPU usage by shards for database",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 9,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_rdb_bgsave_in_progress{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} !=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "BGSAVE Replica:{{crdt_replica_id}} - {{redis}} node {{node}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "redis_aof_rewrite_in_progress{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} !=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "AOFRW Replica:{{crdt_replica_id}} - {{redis}} node {{node}}",
+                  "refId": "B",
+                  "step": 240
+                },
+                {
+                  "expr": "redis_module_fork_in_progress{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} !=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Module fork Replica:{{crdt_replica_id}} - {{redis}} node {{node}}",
+                  "refId": "C",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Forks",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "CPU Usage",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 10,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_no_of_keys{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} or redis_db0_keys{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - redis:{{redis}}, role: {{role}}, node:{{node}}, slots:{{slots}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "# keys/shard",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 11,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_evicted_objects{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Evicted BDB",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "sum by (crdt_replica_id) (redis_keys_trimmed{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"})!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Reshard trimmed BDB - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Evicted objects for database",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 12,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_expired_objects{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Expired objects for database",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Objects",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 13,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "delta(redis_aof_rewrites{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[$aggregation]) !=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - Redis {{redis}} node {{node}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Shard AOF Rewrites / $aggregation",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 14,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_used_memory{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - redis:{{redis}}, role:{{role}}, node:{{node}}, slots:{{slots}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_maxmemory{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - maxmemory: redis:{{redis}}, role:{{role}}, node:{{node}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Sizes of shards for database",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 15,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_read_misses{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Read Misses - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "bdb_write_misses{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Write Misses - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 240
+                },
+                {
+                  "expr": "bdb_read_hits{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Read Hits - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 240
+                },
+                {
+                  "expr": "bdb_write_hits{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Write Hits - Replica:{{crdt_replica_id}}",
+                  "refId": "D",
+                  "step": 240
+                },
+                {
+                  "expr": "delta(redis_total_error_replies{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[60s])/60  ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Error Replies - Replica:{{crdt_replica_id}}",
+                  "refId": "E",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Read/Write Hits / Misses  + lazyfree + errors",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ops",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 16,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_fragmentation{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} or redis_mem_fragmentation_ratio{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - Redis {{redis}} ({{role}})",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Shard RSS fragmentation",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 17,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(bdb_read_hits{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} + bdb_write_hits{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}) / (bdb_read_req{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} + bdb_write_req{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}) > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "DB hit ratio - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Database Hit Ratio (hits / requests)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 18,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_allocator_active{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} - redis_allocator_allocated{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - redis:{{redis}} role:{{role}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Shard allocator fragmentation bytes (defraggable)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 19,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (crdt_replica_id) (redis_mem_fragmentation_ratio{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}) / count by (crdt_replica_id) (redis_mem_fragmentation_ratio{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis_mem_fragmentation_ratio - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "sum by (crdt_replica_id) (redis_allocator_active{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}) / sum by (crdt_replica_id) (redis_allocator_allocated{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Shard allocator fragmentation - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 240
+                },
+                {
+                  "expr": "sum by (crdt_replica_id) (redis_allocator_resident{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}) / sum by (crdt_replica_id) (redis_allocator_active{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard allocator rss - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Database total fragmentation",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 20,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_allocator_active{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} / redis_allocator_allocated{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - redis:{{redis}} role:{{role}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Shard allocator fragmentation % (defraggable)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 21,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_active_defrag_running{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - redis:{{redis}} role:{{role}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Database sum redis active defrag running",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 22,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "delta(redis_aof_delayed_fsync{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[$aggregation])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - Redis {{redis}} ({{role}})",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Delayed fsync - (events / $aggregation)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 23,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_replicaof_syncer_local_ingress_lag_time{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} src_id {{src_id}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "bdb_crdt_syncer_local_ingress_lag_time{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} crdt src_id {{src_id}}",
+                  "refId": "B",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Syncer lag",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ms",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 24,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_crdt_ts_key_headers{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - redis:{{redis}}, role: {{role}}, node:{{node}}, slots:{{slots}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Number of Tombstones",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Dashboard Row",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 25,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_crdt_syncer_status{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 120
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "bdb_crdt_syncer_status: [ in-sync: 0,   syncing: 1,   out-of-sync: 2 ]",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 26,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_crdt_peer_peer_state{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} != 1",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - redis:{{redis}}",
+                  "refId": "A",
+                  "step": 120
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "redis_crdt_peer_peer_state != 1.  [ initialized: 0, online: 1, wait_fullsync: 2, fullsync: 3, fullsync_ack: 4, closed: 5 ]",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 27,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_crdt_stale_replica{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "stale - Replica:{{crdt_replica_id}} - redis:{{redis}}",
+                  "refId": "A",
+                  "step": 120
+                },
+                {
+                  "expr": "redis_crdt_oom_latch{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "oom - Replica:{{crdt_replica_id}} - redis:{{redis}}",
+                  "refId": "C",
+                  "step": 120
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "redis_crdt_stale_replica , redis_crdt_oom_latch",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 28,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_crdt_syncer_ingress_bytes{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "bdb_crdt_syncer_ingress_bytes - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "bdb_crdt_syncer_ingress_bytes",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Synchronization",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 29,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "min by (crdt_replica_id) (redis_crdt_replica_min_ops_lag{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "min lag - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "max by (crdt_replica_id) (redis_crdt_replica_max_ops_lag{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "max lag - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "replica min/max ops lag",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 30,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "max by (crdt_replica_id) (bdb_crdt_syncer_pending_local_writes_max{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "bdb1 max local writes - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "min by (crdt_replica_id) (bdb_crdt_syncer_pending_local_writes_min{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "bdb1 min local writes - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "GC ops lag",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 31,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_crdt_syncer_local_ingress_lag_time{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "syncer_local_ingress_lag_time - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "crdt_syncer_local_ingress_lag_time",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ms",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Synchronization Lag",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 32,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (crdt_replica_id) (delta(redis_crdt_gc_attempted{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "crdt_gc_attempted - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 60
+                },
+                {
+                  "expr": "sum by (crdt_replica_id) (delta(redis_crdt_gc_collected{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "crdt_gc_collected - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 60
+                },
+                {
+                  "expr": "sum by (crdt_replica_id) (redis_crdt_gc_pending{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "gc pending - Replica:{{crdt_replica_id}}",
+                  "refId": "E",
+                  "step": 60
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "CRDT GC",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "CRDT Module",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 33,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_used_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "bdb_used_ram - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "bdb_ram_limit{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "limit (when low, near used) - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB (ROF) used RAM for",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 34,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(bdb_big_fetch_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} + bdb_big_write_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} + bdb_big_del_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}) / (bdb_big_fetch_flash{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} + bdb_big_write_flash{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} + bdb_big_del_flash{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} + bdb_big_fetch_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} + bdb_big_write_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} + bdb_big_del_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}) > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "DB ram hit ratio - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "bdb_big_fetch_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}  / (bdb_big_fetch_flash{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}  + bdb_big_fetch_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} ) > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "read hit ratio - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 240
+                },
+                {
+                  "expr": "bdb_big_write_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}  / (bdb_big_write_flash{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}  + bdb_big_write_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} ) > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "write hit ratio - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 240
+                },
+                {
+                  "expr": "bdb_big_del_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}  / (bdb_big_del_flash{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}  + bdb_big_del_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} ) > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "del hit ratio - Replica:{{crdt_replica_id}}",
+                  "refId": "D",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DB ram hit ratio",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 35,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg by (crdt_replica_id) (delta(redis_big_io_ratio_redis{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"}[1m]))/60",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "RAM Ops for Redis - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "avg by (crdt_replica_id) (delta(redis_big_io_ratio_flash{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"}[1m]) * -1)/60",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Flash Ops for Redis - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 240
+                },
+                {
+                  "expr": "avg by (crdt_replica_id) (delta(redis_big_user_io_ratio_redis{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"}[1m]))/60",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "User RAM Ops for Redis - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 240
+                },
+                {
+                  "expr": "avg by (crdt_replica_id) (delta(redis_big_user_io_ratio_flash{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"}[1m]) * -1)/60",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "User Flash Ops for Redis - Replica:{{crdt_replica_id}}",
+                  "refId": "D",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB RAM:Flash access ratio",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ops",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 36,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "delta(redis_big_io_ratio_redis{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[1m])/60",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "RAM Ops for Redis - Replica:{{crdt_replica_id}} - redis:{{redis}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "delta(redis_big_io_ratio_flash{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[1m]) / -60",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Flash Ops for Redis - Replica:{{crdt_replica_id}} - redis:{{redis}}",
+                  "refId": "B",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "RAM:Flash access ratio",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ops",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 37,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_bigstore_io_read_bytes{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Reads - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "bdb_bigstore_io_write_bytes{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Writes - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Flash IO Banwidth",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 38,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_bigstore_io_reads{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Reads - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "bdb_bigstore_io_writes{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Writes - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 240
+                },
+                {
+                  "expr": "bdb_bigstore_io_dels{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Deletes - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Flash IOPS",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 39,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (crdt_replica_id) (delta(redis_wait_busy_key{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[$aggregation]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB sum redis wait busy key / $aggregation",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 40,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (crdt_replica_id) (delta(redis_blocking_reads{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[$aggregation]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB sum redis blocking reads / $aggregation",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 41,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_used_bigstore{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "used - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "bdb_used_bigstore{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} * bdb_disk_frag_ratio{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "actual - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 240
+                },
+                {
+                  "expr": "bdb_disk_frag_ratio{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "frag ratio - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB used flash",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 42,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_big_postponed_clients{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB postponed clients",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 43,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_big_blocked_clients{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Number of blocked clients - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB blocked clients",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 44,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(bdb_ram_overhead{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} - bdb_mem_not_counted_for_evict{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}) / bdb_ram_limit{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total Ratio - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 240
+                },
+                {
+                  "expr": "(redis_ram_overhead{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} - redis_mem_clients_slaves{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} - redis_mem_aof_buffer{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}) / redis_max_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}} - redis: {{redis}} role:{{role}}",
+                  "refId": "C",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB ram overhead",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 45,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (crdt_replica_id) (rate(redis_blocking_writes{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB sum redis blocking writes",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 46,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (crdt_replica_id) (redis_big_inst_avg_read_io_queue{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB sum redis big inst avg read io queue",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 47,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (crdt_replica_id) (redis_big_inst_avg_write_io_queue{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB sum redis big inst avg write io queue",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 48,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_bigstore_objs_flash{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "objects in flash (sum of all master shards) - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "bdb_bigstore_objs_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "objects in ram (sum of all master shards) - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB objects(values) in FLASH",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 49,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_bigstore_objs_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} / bdb_no_of_keys{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "BDB % values in RAM (masters) - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "avg((max(redis_bigdb0_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"} or redis_bigdb_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"}) by (redis,bdb,crdt_replica_id)) / on (redis,bdb,crdt_replica_id) redis_db0_keys{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "average master shard % values in RAM - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 240
+                },
+                {
+                  "expr": "avg((max(redis_bigdb0_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"} or redis_bigdb_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"}) by (redis,bdb,crdt_replica_id)) / on (redis,bdb,crdt_replica_id) redis_db0_keys{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "average slave shard % values in RAM - Replica:{{crdt_replica_id}}",
+                  "refId": "D",
+                  "step": 240
+                },
+                {
+                  "expr": "topk(1, min((max(redis_bigdb0_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"} or redis_bigdb_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"}) by (redis,bdb,crdt_replica_id)) / on (redis,bdb,cluster) redis_db0_keys{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"}) by (redis) * -1) *-1",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "lowest master shard % values in RAM - redsi:{{redis}} - Replica:{{crdt_replica_id}}",
+                  "refId": "F",
+                  "step": 240
+                },
+                {
+                  "expr": "topk(1, min((max(redis_bigdb0_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"} or redis_bigdb_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"}) by (redis,bdb,crdt_replica_id)) / on (redis,bdb,cluster) redis_db0_keys{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"}) by (redis) * -1) *-1",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "lowest slave shard % values in RAM - redsi:{{redis}} - Replica:{{crdt_replica_id}}",
+                  "refId": "G",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB % values in RAM",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 50,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg(max(redis_bigdb0_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"} or redis_bigdb_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"}) by (redis,bdb,crdt_replica_id))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "average number of values in ram per slave shard - Replica:{{crdt_replica_id}}",
+                  "refId": "D",
+                  "step": 240
+                },
+                {
+                  "expr": "avg(max(redis_bigdb0_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"} or redis_bigdb_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"}) by (redis,bdb,crdt_replica_id))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "average number of values in ram per master shard - Replica:{{crdt_replica_id}}",
+                  "refId": "E",
+                  "step": 240
+                },
+                {
+                  "expr": "topk(1, min(max(redis_bigdb0_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"} or redis_bigdb_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"}) by (redis,bdb,crdt_replica_id) < on(crdt_replica_id,bdb,redis) redis_db0_keys{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"slave\"} ) by (bdb, redis,crdt_replica_id) * -1) * -1",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "lowest number of values in ram per slave shard - redis:{{redis}} - Replica:{{crdt_replica_id}}",
+                  "refId": "F",
+                  "step": 240
+                },
+                {
+                  "expr": "topk(1, min(max(redis_bigdb0_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"} or redis_bigdb_ram{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"}) by (redis,bdb,crdt_replica_id) < on(crdt_replica_id,bdb,redis) redis_db0_keys{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\",role=\"master\"}) by (bdb, redis,crdt_replica_id) * -1) * -1",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "lowest number of values in ram per master shard  - redis:{{redis}} - Replica:{{crdt_replica_id}}",
+                  "refId": "G",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Shard objects(values) in RAM",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 51,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_big_ram_dirty_evictions{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB dirty RAM evictions",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 52,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "bdb_big_ram_clean_evictions{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "BDB clean RAM evictions",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 53,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (crdt_replica_id) (delta(redis_rocks_comp_started{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "compactions - Replica:{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 240
+                },
+                {
+                  "expr": "sum by (crdt_replica_id) (delta(redis_rocks_flush_started{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "flushes - Replica:{{crdt_replica_id}}",
+                  "refId": "B",
+                  "step": 240
+                },
+                {
+                  "expr": "sum by (crdt_replica_id) (delta(redis_rocks_flush_writes_slowdown{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[$aggregation]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "slowdowns / $aggregation - Replica:{{crdt_replica_id}}",
+                  "refId": "C",
+                  "step": 240
+                },
+                {
+                  "expr": "sum by (crdt_replica_id) (delta(redis_rocks_flush_writes_stop{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}[$aggregation]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "stalls / $aggregation - Replica:{{crdt_replica_id}}",
+                  "refId": "D",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "RocksDB",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "ROF Metrics",
+          "titleSize": "h6"
+        }
+      ],
+      "schemaVersion": 14,
+      "style": "light",
+      "tags": [
+        "redis-enterprise",
+        "openshift-observe",
+        "basic"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(redis_server_up, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\"}, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "crdt_guid",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", cluster=\"$cluster\"}, crdt_guid)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "1m",
+            "current": {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "aggregation",
+            "options": [],
+            "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "utc",
+      "title": "Redis Enterprise / Basic / Synchronization (Classic)",
+      "uid": "re-observe-basic-synchronization",
+      "version": 1
+    }

--- a/openshift/native-observe/dashboards/redis-enterprise-ops-active-active-lag.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-ops-active-active-lag.yaml
@@ -1,0 +1,983 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-enterprise-ops-active-active-lag
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+data:
+  redis-enterprise-ops-active-active-lag.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "links": [],
+      "refresh": "30s",
+      "rows": [
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 1,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "database_syncer_dst_lag{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "R{{source_id}}:({{hash_slots}}) -> R{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Source -> Target lag in time per shard",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ms",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 2,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "((database_syncer_dst_repl_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"} and database_syncer_src_repl_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"} < database_syncer_dst_repl_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"}) or database_syncer_dst_repl_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"}) - database_syncer_src_repl_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "R{{source_id}}: ({{hash_slots}}) -> R{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total lag in bytes per shard",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 3,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(redis_server_crdt_backlog_master_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"} - on(crdt_replica_id, redis) group_right redis_server_crdt_peer_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", dst_id=~\"$crdt_replica_id\"}) / on(crdt_replica_id, redis) group_left redis_server_crdt_backlog_size{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "R{{crdt_replica_id}}:shard {{redis}}:({{slots}}) -> R{{dst_id}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Peer backlog status",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 4,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "((database_syncer_syncer_repl_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"} and database_syncer_src_repl_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"} < database_syncer_syncer_repl_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"}) or database_syncer_src_repl_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"}) - database_syncer_syncer_repl_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "R{{source_id}}:({{hash_slots}}) -> R{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Source -> Syncer lag in bytes",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 5,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "database_syncer_syncer_repl_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"} - database_syncer_dst_repl_offset{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "R{{source_id}}:({{hash_slots}}) -> R{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Syncer -> Target lag in bytes",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 6,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "database_syncer_total_requests{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"} - database_syncer_total_responses{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "R{{source_id}}:({{hash_slots}}) -> R{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Target pipeline",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 7,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "database_syncer_ingress_bytes{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "R{{src_id}} -> R{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total ingress bytes",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 8,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "database_syncer_ingress_bytes_decompressed{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "R{{src_id}} -> R{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total ingress bytes decompressed",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 9,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(database_syncer_ingress_bytes{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"}[$__interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "R{{source_id}}:({{hash_slots}}) -> R{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Ingress bytes per shard",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 10,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(database_syncer_ingress_bytes_decompressed{namespace=\"$namespace\", crdt_guid=\"$crdt_guid\", crdt_replica_id=~\"$crdt_replica_id\"}[$__interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "R{{source_id}}:({{hash_slots}}) -> R{{crdt_replica_id}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Ingress bytes decompressed per shard",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Lag Metrics",
+          "titleSize": "h6"
+        }
+      ],
+      "schemaVersion": 14,
+      "style": "light",
+      "tags": [
+        "redis-enterprise",
+        "openshift-observe",
+        "ops"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(redis_server_up, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\"}, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "crdt_guid",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", cluster=\"$cluster\"}, crdt_guid)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "crdt_replica_id",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", cluster=\"$cluster\"}, crdt_replica_id)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "1m",
+            "current": {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "aggregation",
+            "options": [],
+            "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "utc",
+      "title": "Redis Enterprise / Ops / Active-Active Lag",
+      "uid": "re-observe-ops-active-active-lag",
+      "version": 1
+    }

--- a/openshift/native-observe/dashboards/redis-enterprise-ops-cluster.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-ops-cluster.yaml
@@ -1,0 +1,1933 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-enterprise-ops-cluster
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+data:
+  redis-enterprise-ops-cluster.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "links": [],
+      "refresh": "30s",
+      "rows": [
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 1,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "node_metrics_up{namespace=\"$namespace\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Name",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 2,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "count by (extracted_os_version) (\n  label_replace(node_os_version{namespace=\"$namespace\", cluster=\"$cluster\"}, \"extracted_os_version\", \"$1\", \"id\", \"(.*)\")\n)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{id}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "OS version",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 3,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "node_config{namespace=\"$namespace\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Enterprise Version",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 4,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "count(db_config{namespace=\"$namespace\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "# Databases",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 5,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db) (rate(redis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Database: {{db}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Grow Over Minute (Over 100MiB)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 6,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(redis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total Used",
+                  "refId": "A",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(node_available_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total Available",
+                  "refId": "B",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(node_provisional_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total Provisional",
+                  "refId": "D",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(node_provisional_memory_no_overbooking_bytes{namespace=\"$namespace\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total Provisional (No Overbooking)",
+                  "refId": "C",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Used Memory",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 7,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "count (db_status{namespace=\"$namespace\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total databases ",
+                  "refId": "A",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total Databases Count Over Time",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 8,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "topk(10,\n  sum by (db) (\n    (\n      redis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\", role=\"master\"}\n      * on(db, cluster) group_left\n        db_replication_factor\n    )\n    or\n    (\n      redis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\"}\n      unless on(db, cluster) db_replication_factor\n    )\n  )\n)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Database: {{db}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Top 10 Memory Per Database",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 9,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg by(cluster) ((sum by(cluster, db) (redis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\"}) / avg by(cluster, db) (db_memory_limit_bytes{namespace=\"$namespace\", cluster=\"$cluster\"}) / avg by(cluster, db) (db_replication_factor{namespace=\"$namespace\", cluster=\"$cluster\"})) * 100)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Memory Load % ",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Memory Load Over Time ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 10,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_allocator_active{namespace=\"$namespace\", cluster=\"$cluster\"} - redis_server_allocator_allocated{namespace=\"$namespace\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Database: {{db}} Redis: {{redis}}",
+                  "refId": "A",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Active - Allocated (Defraggable)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 11,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(redis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total shards memory",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(redis_server_used_ram{namespace=\"$namespace\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total shards ram",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total Shards Memory",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 12,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "node_available_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Available memory: node {{node}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Available Memory per node",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Overview",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 13,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "100 * (1 - avg(irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"idle\", node=\"$node\", cluster=\"$cluster\"}[$__rate_interval])) by (node))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "total CPU utilization",
+                  "refId": "F",
+                  "step": 10
+                },
+                {
+                  "expr": "avg by (node) (irate(node_cpu_seconds_total{namespace=\"$namespace\", mode=\"idle\", node=\"$node\", cluster=\"$cluster\"}[$__rate_interval]))*100",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "idle",
+                  "refId": "A",
+                  "step": 2
+                },
+                {
+                  "expr": "avg(rate(node_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",mode=\"iowait\"}[$__rate_interval])) by (node)*100",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "iowait",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", mode=~\"system|user\", cluster=\"$cluster\", node=\"$node\"}*0.0001)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shards (100% = 1 core)",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "avg(rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\", groupname=\"dmcproxy\"}[$__rate_interval])) by (node) ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "dmcproxy (100% = 1 core)",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "avg(rate(node_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",mode=\"nice\"}[$__rate_interval])) by (node)*100",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "nice",
+                  "refId": "E",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "CPU Usage for node $node",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "CPU",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 14,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "100*(1 - \n  node_filesystem_avail_bytes{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\", fstype!~\"overlay|tmpfs|efivarfs\", mountpoint!=\"/boot/efi\" } \n/\n  node_filesystem_size_bytes{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\", fstype!~\"overlay|tmpfs|efivarfs\", mountpoint!=\"/boot/efi\"}\n)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Mount: {{mountpoint}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Node $node: Average Disk Usage by Mount as a %",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Storage",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 15,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "topk(10, histogram_quantile(0.99, sum(rate(endpoint_read_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\"}[1m])) by (le, db)))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "p99_read databases: {{db}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "topk(10, histogram_quantile(0.99, sum(rate(endpoint_write_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\"}[1m])) by (le, db)))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "p99_write databases: {{db}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Top 10 Read and Write Requests Latency (P99) ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 16,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "topk(10, histogram_quantile(0.95, sum(rate(endpoint_write_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\"}[1m])) by (le, db)))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "p95_read databases: {{db}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "topk(10, histogram_quantile(0.95, sum(rate(endpoint_write_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\"}[1m])) by (le, db)))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "p95_write databases: {{db}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Top 10 Read and Write Requests Latency (P95) ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 17,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "topk(10, sum by(db) (endpoint_conns{namespace=\"$namespace\", cluster=\"$cluster\"}))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Connections by database: {{db}} ",
+                  "refId": "A",
+                  "step": 2
+                },
+                {
+                  "expr": "topk(10, endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\"} - endpoint_client_disconnections{namespace=\"$namespace\", cluster=\"$cluster\"} - endpoint_proxy_disconnections{namespace=\"$namespace\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Active endpoint client connections for database: {{db}}",
+                  "refId": "B",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Top 10 Used Connections By Database (All Nodes)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 18,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "topk(10, sum(rate(endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\"}[$__rate_interval]) + rate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\"}[$__rate_interval]) + rate(endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\"}[$__rate_interval])) by (db, proxy))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "listener: {{proxy}} for database: {{db}}",
+                  "refId": "A",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Top 10 Active Listeners By Requests (Read/Write/Other)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 19,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "- sum (rate(endpoint_egress{namespace=\"$namespace\", cluster=\"$cluster\"}[$__rate_interval])) by (db) ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Egress for database: {{db}}",
+                  "refId": "A",
+                  "step": 2
+                },
+                {
+                  "expr": "sum (rate(endpoint_ingress{namespace=\"$namespace\", cluster=\"$cluster\"}[$__rate_interval])) by (db)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Ingress for database: {{db}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total Traffic",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Databases traffic",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 20,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_used_memory{namespace=\"$namespace\", node=\"$node\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Database: {{db}} Redis: {{redis}}",
+                  "refId": "A",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Used Mem By redis for Node $node",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Memory",
+          "titleSize": "h6"
+        }
+      ],
+      "schemaVersion": 14,
+      "style": "light",
+      "tags": [
+        "redis-enterprise",
+        "openshift-observe",
+        "ops"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(redis_server_up, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\"}, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "node",
+            "options": [],
+            "query": "label_values(node_metrics_up{namespace=\"$namespace\", cluster=\"$cluster\"}, node)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "db",
+            "options": [],
+            "query": "label_values(endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\"},db)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "shard",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}, redis)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "1m",
+            "current": {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "aggregation",
+            "options": [],
+            "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "utc",
+      "title": "Redis Enterprise / Ops / Cluster Dashboard",
+      "uid": "re-observe-ops-cluster",
+      "version": 1
+    }

--- a/openshift/native-observe/dashboards/redis-enterprise-ops-database.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-ops-database.yaml
@@ -1,0 +1,2957 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-enterprise-ops-database
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+data:
+  redis-enterprise-ops-database.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "links": [],
+      "refresh": "30s",
+      "rows": [
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 1,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "db_config{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{db_name}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Name",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 2,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "db_config{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Redis Version",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 3,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum by (db)(endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"} - endpoint_client_disconnections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} - endpoint_proxy_disconnections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "current number of active connections",
+                  "refId": "A",
+                  "step": 2
+                }
+              ],
+              "thresholds": "",
+              "title": "#Connections",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 4,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "count(endpoint_read_requests{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "#Endpoints",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 5,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg(rate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval]) + rate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval]) + rate(endpoint_other_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval])) by (proxy, node) / avg(rate(endpoint_write_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval]) + rate(endpoint_read_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval]) + rate(endpoint_other_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval])) by (proxy, node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "proxy: {{proxy}} , node {{node}} - sum requests latency",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval]) / rate(endpoint_write_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "proxy: {{proxy}} , node {{node}} - write requests latency",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval]) / rate(endpoint_read_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "proxy: {{proxy}} , node {{node}} - read requests latency",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(endpoint_other_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval]) / rate(endpoint_other_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "proxy: {{proxy}} , node {{node}} - other requests latency",
+                  "refId": "D",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Avg Database Requests Latency ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 6,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg(\n  (\n    rate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\", proxy=~\".*\"}[$__rate_interval])\n    +\n    rate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\", proxy=~\".*\"}[$__rate_interval])\n    +\n    rate(endpoint_other_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\", proxy=~\".*\"}[$__rate_interval])\n  )\n  /\n  (\n    rate(endpoint_write_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\", proxy=~\".*\"}[$__rate_interval])\n    +\n    rate(endpoint_read_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\", proxy=~\".*\"}[$__rate_interval])\n    +\n    rate(endpoint_other_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\", proxy=~\".*\"}[$__rate_interval])\n  )\n) by (proxy, node, db)\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "listener {{proxy}}  node {{node}} - listener_acc_latency",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "(\n  sum(irate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", db=\"$db\", proxy=~\".*\"}[$__rate_interval])) by (node,proxy)\n  /\n  sum(irate(endpoint_write_requests_latency_histogram_count{namespace=\"$namespace\", db=\"$db\", proxy=~\".*\"}[$__rate_interval])) by (node,proxy)\n)\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "listener {{proxy}}  node {{node}} - listener_acc_write_latency",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "(\n  sum(irate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", db=\"$db\", proxy=~\".*\"}[$__rate_interval])) by (proxy,node)\n  /\n  sum(irate(endpoint_read_requests_latency_histogram_count{namespace=\"$namespace\", db=\"$db\", proxy=~\".*\"}[$__rate_interval])) by (proxy,node)\n)\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "listener {{proxy}}  node {{node}} - listener_acc_read_latency",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "(\n  sum(irate(endpoint_other_requests_latency_histogram_sum{namespace=\"$namespace\", db=\"$db\", proxy=~\".*\"}[$__rate_interval])) by (proxy,node)\n  /\n  sum(irate(endpoint_other_requests_latency_histogram_count{namespace=\"$namespace\", db=\"$db\", proxy=~\".*\"}[$__rate_interval])) by (proxy,node)\n)\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "proxy {{proxy}} node {{node}} - listener_acc_other_latency",
+                  "refId": "D",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Avg Endpoint Requests Latency ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 7,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db) (\n(\nredis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\", role=\"master\"}\n* on(db, cluster) group_left\ndb_replication_factor\n)\nor\n(\nredis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\"}\nunless on(db, cluster) db_replication_factor\n)\n)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Used Memory (Logical)",
+                  "refId": "A",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(redis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Used Memory Sum Of Shards",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by (db) (redis_server_current_cow_size{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Used Memory Copy On Write",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by (db) (namedprocess_namegroup_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\",memtype=\"resident\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Used Memory RSS",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by (db) (db_memory_limit_bytes{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}) and on(db) (((sum by (cluster, db) (redis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) / avg by (cluster, db) (db_memory_limit_bytes{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})) / avg by (cluster, db) (db_replication_factor{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})) > 0.8)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "limit (when low, near used)",
+                  "refId": "E",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Memory Utilization",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 8,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db) (rate(endpoint_total_req{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total requests",
+                  "refId": "A",
+                  "step": 2
+                },
+                {
+                  "expr": "sum by (db) (rate(endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Other requests",
+                  "refId": "B",
+                  "step": 2
+                },
+                {
+                  "expr": "sum by (db) (rate(endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Read requests",
+                  "refId": "C",
+                  "step": 2
+                },
+                {
+                  "expr": "sum by (db) (rate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Write requests",
+                  "refId": "D",
+                  "step": 2
+                },
+                {
+                  "expr": "sum by (cluster, db) (\n            rate(endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) +\n            rate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) +\n            rate(endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])\n        )",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total requests (max)",
+                  "refId": "E",
+                  "step": 240
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Requests[total,read,write,other] ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ops",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 9,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_instantaneous_ops_per_sec{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "node: {{node}},  redis: {{redis}}, role: {{role}},  slots: {{slots}} ",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Real-Time Ops Per Second (Instantaneous)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ops",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 10,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "- sum by(db) (rate(endpoint_egress{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Endpoint Egress",
+                  "refId": "A",
+                  "step": 2
+                },
+                {
+                  "expr": "sum by(db) (rate(endpoint_ingress{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Endpoint Ingress",
+                  "refId": "B",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(rate(redis_server_total_net_input_bytes{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Master shard Ingress",
+                  "refId": "C",
+                  "step": 2
+                },
+                {
+                  "expr": "- (sum(rate(redis_server_total_net_output_bytes{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}[1m]) - rate(redis_server_master_repl_offset{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}[1m])))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Master shard Egress",
+                  "refId": "E",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(rate(redis_server_master_repl_offset{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Master shard replication",
+                  "refId": "F",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(rate(redis_server_repl_touch_bytes{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}[1m]))!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Master shard repl touch",
+                  "refId": "G",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Endpoint Ingress/Egress",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 11,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} - endpoint_client_disconnections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} )",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} - endpoint_client_disconnections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} ) by (proxy, node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "endpoint {{proxy}} node: {{node}}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "connections rate per minute for db:$db - node: {{node}}",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(endpoint_client_disconnections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} [$__rate_interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "disconnections rate per minute for db:$db - node: {{node}}",
+                  "refId": "C",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Connection Overview",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 12,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", mode=\"user\"}[60s])*100) by (groupname, redis, role, node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "user: redis: {{redis}} role: {{role}} node:{{node}}",
+                  "refId": "B",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", mode=\"system\"}[60s])*100) by (groupname, redis, role, node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "system: redis: {{redis}} role: {{role}} node:{{node}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "CPU Usage Per  Shards",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 13,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Memory Usage redis: {{redis}} role: {{role}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_current_cow_size{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Memory Usage Copy On Write - redis: {{redis}} role: {{role}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Memory Utilization Per Shard",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Overview",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 14,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_db_keys{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", redis=~\"$redis\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}, role: {{role}}, node:{{node}}, slots:{{slots}}",
+                  "refId": "A",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "#Keys Per Shard",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 15,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db) (redis_server_db_keys{namespace=\"$namespace\", role=\"master\", db=\"$db\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "num of keys",
+                  "refId": "A",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(redis_server_db_expires{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\",role=\"master\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "num of volatile keys",
+                  "refId": "B",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(max(redis_server_bigdb_ram{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\",role=\"master\"}) by (redis,db,cluster))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "ram keys",
+                  "refId": "C",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(max(redis_server_bigdb_disk{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\",role=\"master\"}) by (redis,db,cluster))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "disk keys",
+                  "refId": "D",
+                  "step": 2
+                },
+                {
+                  "expr": "(sum(max(redis_server_bigdb_disk{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\",role=\"master\"}) by (redis,db,cluster)) + sum(max(redis_server_bigdb_ram{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\",role=\"master\"} ) by (redis,db,cluster))) - sum(redis_server_db_keys{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\",role=\"master\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "overlapping keys",
+                  "refId": "E",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(max(redis_server_bigdb_dirty{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\",role=\"master\"}) by (redis,db,cluster))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "dirty keys",
+                  "refId": "F",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(max(redis_server_bigdb_clean{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\",role=\"master\"}) by (redis,db,cluster))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "clean keys",
+                  "refId": "G",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "#Keys",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 16,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db) (irate(redis_server_expired_keys{namespace=\"$namespace\", role=\"master\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Expired database:$db",
+                  "refId": "C",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Expired Objects",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 17,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db) (irate(redis_server_evicted_keys{namespace=\"$namespace\", role=\"master\", db=\"$db\", cluster=\"$cluster\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Evicted database:$db",
+                  "refId": "A",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(rate(redis_server_keys_trimmed{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[1m]))!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Reshard trimmed database:$db",
+                  "refId": "B",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Evicted Objects",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Keyspace",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 18,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.999, sum(rate(endpoint_read_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db)) ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Read",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "histogram_quantile(0.999, sum(rate(endpoint_write_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db)) ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Write",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "histogram_quantile(0.999, sum(rate(endpoint_other_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db)) ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Other",
+                  "refId": "C",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "p99.9 Latency (µs) Over Time [read, write, other requests]",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 19,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(endpoint_read_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Read",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(endpoint_write_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Write",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(endpoint_other_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Other",
+                  "refId": "C",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "p99 Latency (µs) Over Time [read, write, other requests]",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 20,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.50, sum(rate(endpoint_read_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Read",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "histogram_quantile(0.50, sum(rate(endpoint_write_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Write",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "histogram_quantile(0.50, sum(rate(endpoint_other_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Other",
+                  "refId": "C",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "p50 Latency (µs) Over Time [read, write, other requests]",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Latency",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 21,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_connected_clients{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Redis: {{redis}}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_maxclients{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"} < redis_server_connected_clients{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"} * 1.5",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Redis {{redis}} maxclients",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_pubsub_clients{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Redis: {{redis}} pubsub clients",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_blocked_clients{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Redis: {{redis}} blocked clients",
+                  "refId": "D",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Connections Per (master) Shard",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 22,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 5,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db) (rate(redis_server_keyspace_read_hits{namespace=\"$namespace\", role=\"master\", db=\"$db\"}[$__rate_interval])) / (sum by (db)(rate(redis_server_keyspace_read_hits{namespace=\"$namespace\", role=\"master\", db=\"$db\"}[$__rate_interval]) + rate(redis_server_keyspace_read_misses{namespace=\"$namespace\", role=\"master\", db=\"$db\"}[$__rate_interval]))) ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "READ {{label_name}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by (db) (rate(redis_server_keyspace_write_hits{namespace=\"$namespace\", role=\"master\", db=\"$db\"}[$__rate_interval])) / (sum by (db)(rate(redis_server_keyspace_write_hits{namespace=\"$namespace\", role=\"master\", db=\"$db\"}[$__rate_interval]) + rate(redis_server_keyspace_write_misses{namespace=\"$namespace\", role=\"master\", db=\"$db\"}[$__rate_interval]))) \n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "WRITE {{label_name}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Hit Ratio (hits / requests)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 23,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db) (irate(redis_server_keyspace_read_misses{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Read Misses",
+                  "refId": "A",
+                  "step": 2
+                },
+                {
+                  "expr": "sum by (db) (irate(redis_server_keyspace_write_misses{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Write Misses",
+                  "refId": "B",
+                  "step": 2
+                },
+                {
+                  "expr": "sum by (db) (irate(redis_server_keyspace_read_hits{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Read Hits",
+                  "refId": "C",
+                  "step": 2
+                },
+                {
+                  "expr": "sum by (db) (irate(redis_server_keyspace_write_hits{namespace=\"$namespace\", role=\"master\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Write Hits",
+                  "refId": "D",
+                  "step": 2
+                },
+                {
+                  "expr": "delta(redis_server_lazyfreed_objects{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[60s])/60",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Lazy Free",
+                  "refId": "E",
+                  "step": 2
+                },
+                {
+                  "expr": "delta(redis_server_total_error_replies{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[60s])/60",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Error Replies",
+                  "refId": "F",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Read/Write Hits / Misses  + Lazyfree + Errors",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ops",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 24,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db) (redis_server_blocked_clients{namespace=\"$namespace\", db=\"$db\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Number of blocked clients",
+                  "refId": "A",
+                  "step": 1200
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Blocked Clients",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Connectivity ",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 25,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": " redis_server_mem_fragmentation_ratio{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"} ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Redis {{redis}} ({{role}})",
+                  "refId": "A",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Shard RSS Fragmentation",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Memory ",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 26,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "max by (db,redis) (redis_server_master_repl_offset{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\", role=\"master\"}) - max by (db,redis) (redis_server_slave_offset{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\", role=\"master\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Redis: {{redis}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Replication Offset Difference (Primary vs. Replica)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Replication",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 27,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (db)(redis_server_aof_delayed_fsync{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "avg number of times fsync has been delayed",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by (db)(redis_server_mem_aof_buffer{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "size of the AOF buffer over time",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "AOF To Replica/Primary Lag Monitoring ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 28,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "delta(redis_server_aof_delayed_fsync{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}[$aggregation])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Redis {{redis}} ({{role}})",
+                  "refId": "A",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Delayed Fsync - (Events / $aggregation) ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Persistency",
+          "titleSize": "h6"
+        }
+      ],
+      "schemaVersion": 14,
+      "style": "light",
+      "tags": [
+        "redis-enterprise",
+        "openshift-observe",
+        "ops"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(redis_server_up, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\"}, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "db",
+            "options": [],
+            "query": "label_values(endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\"},db)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "status",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}, status)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "newStatus",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}, status)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "1m",
+            "current": {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "aggregation",
+            "options": [],
+            "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "crdt_guid",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", cluster=\"$cluster\"}, crdt_guid)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "db_name",
+            "options": [],
+            "query": "label_values(db_config{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}, db_name)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "role",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}, role)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "redis",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}, redis)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "utc",
+      "title": "Redis Enterprise / Ops / Database Dashboard",
+      "uid": "re-observe-ops-database",
+      "version": 1
+    }

--- a/openshift/native-observe/dashboards/redis-enterprise-ops-latency.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-ops-latency.yaml
@@ -1,0 +1,2047 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-enterprise-ops-latency
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+data:
+  redis-enterprise-ops-latency.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "links": [],
+      "refresh": "30s",
+      "rows": [
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 1,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg(rate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) + \r\nrate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) + \r\nrate(endpoint_other_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])\r\n) by (db) / avg(rate(endpoint_read_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) + \r\nrate(endpoint_write_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) + \r\nrate(endpoint_other_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])\r\n) by (db)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "database avg latency",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) /  rate(endpoint_write_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "database avg write latency",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) / rate(endpoint_read_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "database avg read latency",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(endpoint_other_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) / rate(endpoint_other_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "database avg other latency",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "max_over_time((\r\n  rate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) + \r\n  rate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) + \r\n  rate(endpoint_other_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])\r\n)[$aggregation:]) / max_over_time((\r\n  rate(endpoint_read_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) + \r\n  rate(endpoint_write_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) + \r\n  rate(endpoint_other_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])\r\n)[$aggregation:])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "database avg latency max",
+                  "refId": "F",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Avg Latency",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 2,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg(rate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval])) by (proxy, node, db) / avg(rate(endpoint_write_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval])) by (proxy, node, db)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "listener {{proxy}}  node {{node}} - listener_acc_write_latency",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "avg(rate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval])) by (proxy, node, db) / avg(rate(endpoint_read_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval]))  by (proxy, node, db)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "listener {{proxy}}  node {{node}} - listener_acc_read_latency",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "avg(rate(endpoint_other_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval])) by (proxy, node, db) / avg(rate(endpoint_other_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", db=~\"$db.*\"}[$__rate_interval])) by (proxy, node, db)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "listener {{proxy}}  node {{node}} - listener_acc_other_latency",
+                  "refId": "D",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Avg Proxy Latency ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 3,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.95, sum(rate(endpoint_read_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Read",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "histogram_quantile(0.95, sum(rate(endpoint_write_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Write",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "histogram_quantile(0.95, sum(rate(endpoint_other_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Other",
+                  "refId": "C",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "p95 Latencies for Read, Write, and Other Requests",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 4,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(endpoint_read_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Read",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(endpoint_write_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Write",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(endpoint_other_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Other",
+                  "refId": "C",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "p99 Latencies for Read, Write, and Other Requests",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 5,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.999, sum(rate(endpoint_read_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Read",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "histogram_quantile(0.999, sum(rate(endpoint_write_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Write",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "histogram_quantile(0.999, sum(rate(endpoint_other_requests_latency_histogram_bucket{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) ) by (le, db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Other",
+                  "refId": "C",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "p99.9 Latencies for Read, Write, and Other Requests",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Proxy Latency",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 6,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg(label_replace(\r\n  avg(rate(namedprocess_namegroup_thread_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", mode=\"system\", groupname=~\".*redis-.*\", threadname=~\".*redis-server.*\"}[$__rate_interval])) by (groupname, mode),\r\n  \"shard_number\", \"$1\", \"groupname\", \".*redis-(\\\\d+)\"\r\n)\r\n* on (shard_number) group_left(db)\r\nlabel_replace(redis_server_up{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\",role=\"master\"}, \"shard_number\", \"$1\", \"redis\", \"(.*)\")) by (db)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "main threads (masters) system, databases: {{db}}",
+                  "refId": "G",
+                  "step": 10
+                },
+                {
+                  "expr": "avg(label_replace(\r\n  avg(rate(namedprocess_namegroup_thread_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", mode=\"user\", groupname=~\".*redis-.*\", threadname=~\".*redis-server.*\"}[$__rate_interval])) by (groupname, mode),\r\n  \"shard_number\", \"$1\", \"groupname\", \".*redis-(\\\\d+)\"\r\n)\r\n* on (shard_number) group_left(db)\r\nlabel_replace(redis_server_up{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\",role=\"master\"}, \"shard_number\", \"$1\", \"redis\", \"(.*)\")) by (db)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "main threads (masters) user, databases: {{db}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(irate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", mode=~\"system|user\",db=\"$db\"}[1m])) by (db, mode)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "all threads (masters), databases: {{db}}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "avg(label_replace(\r\n  avg(rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", mode=\"user\", groupname=~\".*redis-.*\"}[$__rate_interval])) by (groupname, mode),\r\n  \"shard_number\", \"$1\", \"groupname\", \".*redis-(\\\\d+)\"\r\n)\r\n* on (shard_number) group_left(db)\r\nlabel_replace(redis_server_current_fork_perc{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}, \"shard_number\", \"$1\", \"redis\", \"(.*)\")) by (db)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "all forks (masters) - user, databases: {{db}}",
+                  "refId": "I",
+                  "step": 10
+                },
+                {
+                  "expr": "avg(label_replace(\r\n  avg(rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", mode=\"system\", groupname=~\".*redis-.*\"}[$__rate_interval])) by (groupname, mode),\r\n  \"shard_number\", \"$1\", \"groupname\", \".*redis-(\\\\d+)\"\r\n)\r\n* on (shard_number) group_left(db)\r\nlabel_replace(redis_server_current_fork_perc{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}, \"shard_number\", \"$1\", \"redis\", \"(.*)\")) by (db)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "all forks (masters) - system, databases: {{db}}",
+                  "refId": "J",
+                  "step": 10
+                },
+                {
+                  "expr": "max(label_replace(\r\n  avg(rate(namedprocess_namegroup_thread_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", mode=\"user\", groupname=~\".*redis-.*\", threadname=~\".*redis-server.*\"}[$__rate_interval])) by (groupname, mode),\r\n  \"shard_number\", \"$1\", \"groupname\", \".*redis-(\\\\d+)\"\r\n)\r\n* on (shard_number) group_left(db)\r\nlabel_replace(redis_server_up{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\",role=\"master\"}, \"shard_number\", \"$1\", \"redis\", \"(.*)\")) by (db)\r\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "main threads max (masters) - user",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "max(label_replace(\r\n  avg(rate(namedprocess_namegroup_thread_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", mode=\"system\", groupname=~\".*redis-.*\", threadname=~\".*redis-server.*\"}[$__rate_interval])) by (groupname, mode),\r\n  \"shard_number\", \"$1\", \"groupname\", \".*redis-(\\\\d+)\"\r\n)\r\n* on (shard_number) group_left(db)\r\nlabel_replace(redis_server_up{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\",role=\"master\"}, \"shard_number\", \"$1\", \"redis\", \"(.*)\")) by (db)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "main threads max (masters) - system",
+                  "refId": "K",
+                  "step": 10
+                },
+                {
+                  "expr": "max(irate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", mode=~\"system|user\",db=\"$db\"}[1m])) by (db, mode)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "all threads max (masters) ",
+                  "refId": "L",
+                  "step": 10
+                },
+                {
+                  "expr": "avg(irate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", mode=\"system\",db=\"$db\", role=\"slave\"}[1m])) by (db, mode)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Slave main threads",
+                  "refId": "H",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total CPU Utilization",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 7,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg(irate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", mode=\"user\",db=\"$db\"}[1m])) by (redis, role, mode, node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard: {{redis}}, role: {{role}}, node: {{node}},  mode: {{mode}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "avg(irate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", mode=\"system\",db=\"$db\"}[1m])) by (redis, role, mode, node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard: {{redis}}, role: {{role}}, node: {{node}},  mode: {{mode}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "CPU Usage By Shards ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 8,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\",groupname=\"dmcproxy\", mode=~\"user|system\"}[$aggregation])) by (node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "CPU Total node {{node}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Proxy CPU Usage Total ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "CPU Usage",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 9,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "avg(rate(endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]) + rate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]) + rate(endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Avg OPS Per Second",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 10,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum (rate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"}[$__rate_interval]) + rate(endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"}[$__rate_interval]) + rate(endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"}[$__rate_interval])) ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total requests",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(rate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total Write",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(rate(endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total Read",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(rate(endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total Other",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(irate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"}[1m])) by (proxy, node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "endpoint: {{proxy}} node: {{node}} write",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(irate(endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"}[1m])) by (proxy, node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "endpoint: {{proxy}} node: {{node}} read",
+                  "refId": "F",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(irate(endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\"}[1m])) by (proxy, node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "endpoint: {{proxy}} node: {{node}} other",
+                  "refId": "G",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "OPS Per Second Rate",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ops",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 11,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum(endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} - endpoint_client_disconnections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} - endpoint_proxy_disconnections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "#Connections",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 12,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} - endpoint_client_disconnections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} )",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} - endpoint_client_disconnections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} ) by (proxy, node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "endpoint {{proxy}} node: {{node}}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) - rate(endpoint_client_disconnections{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} [$__rate_interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "connections per minute for db:$db - node: {{node}}",
+                  "refId": "D",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Connection Overview",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 13,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\",groupname=\"dmcproxy\", mode=\"user\"}[$aggregation])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "CPU User node {{node}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Proxy CPU Usage User ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 14,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\",groupname=\"dmcproxy\", mode=\"system\"}[$aggregation])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "CPU System node: {{node}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Proxy CPU Usage System",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Proxy",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 15,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "- sum(rate(endpoint_egress{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "endpoint {{proxy}} node {{node}} egress",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(rate(endpoint_ingress{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "endpoint {{proxy}} node {{node}} ingress",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Ingress/Egress",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 16,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "- rate(endpoint_egress{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "endpoint {{proxy}} node {{node}} egress",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(endpoint_ingress{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "endpoint {{proxy}} node {{node}} ingress",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Ingress/Egress By Endpoint",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 17,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(redis_server_total_net_input_bytes{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Master shard Ingress - shard {{ redis }}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": " - (rate(redis_server_total_net_input_bytes{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}[1m]) - rate(redis_server_master_repl_offset{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Master shard Egress - shard {{ redis }}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_master_repl_offset{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Master shard replication - shard {{ redis }}",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(rate(redis_server_repl_touch_bytes{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\", role=\"master\"}[1m]))!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Master shard repl touch",
+                  "refId": "D",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Ingress/Egress By Shards",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Ingress/Egress",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 18,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "topk(10, avg(irate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\"}[1m]) + irate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\"}[1m]) + irate(endpoint_other_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\"}[1m])) by (db) / avg(irate(endpoint_read_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\"}[1m]) + irate(endpoint_write_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\"}[1m]) + irate(endpoint_other_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\"}[1m])) by (db))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Latency for database: {{db}} ",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Top Databases By Latency In Cluster",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Cluster",
+          "titleSize": "h6"
+        }
+      ],
+      "schemaVersion": 14,
+      "style": "light",
+      "tags": [
+        "redis-enterprise",
+        "openshift-observe",
+        "ops"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(redis_server_up, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\"}, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "db",
+            "options": [],
+            "query": "label_values(db_status{namespace=\"$namespace\", cluster=\"$cluster\"}, db)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "status",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}, status)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "newStatus",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}, status)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "redis",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}, redis)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "role",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}, role)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "slots",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}, slots)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "node",
+            "options": [],
+            "query": "label_values(node_metrics_up{namespace=\"$namespace\", cluster=\"$cluster\"}, node)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "1m",
+            "current": {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "aggregation",
+            "options": [],
+            "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "utc",
+      "title": "Redis Enterprise / Ops / Latency Dashboard",
+      "uid": "re-observe-ops-latency",
+      "version": 1
+    }

--- a/openshift/native-observe/dashboards/redis-enterprise-ops-node.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-ops-node.yaml
@@ -1,0 +1,2290 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-enterprise-ops-node
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+data:
+  redis-enterprise-ops-node.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "links": [],
+      "refresh": "30s",
+      "rows": [
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 1,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "node_config{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Enterprise Version ",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "bytes",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 2,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "node_available_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\",node=\"$node\"} or node_available_memory_no_overbooking_bytes{namespace=\"$namespace\", cluster=\"$cluster\",node=\"$node\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Free RAM",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 3,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "node_os_info{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{name}} {{version}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "OS version",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 4,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "node_dmi_info{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{system_vendor}} {{product_name}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Instance",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Overview",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 5,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(rate(node_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",mode!=\"idle\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total Used",
+                  "refId": "H",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(rate(node_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",mode=\"user\"}[$__rate_interval])) by (node) + sum(rate(node_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",mode=\"system\"}[$__rate_interval])) by (node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "user+system",
+                  "refId": "B",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\", groupname=~\"redis-.*\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shards system",
+                  "refId": "I",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\", groupname=\"dmcproxy\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "dmcproxy",
+                  "refId": "G",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(rate(node_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",mode=\"nice\"}[$__rate_interval])) by (node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "nice",
+                  "refId": "E",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(rate(node_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",mode=\"steal\"}[$__rate_interval])) by (node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "steal",
+                  "refId": "D",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(rate(node_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",mode=\"softirq\"}[$__rate_interval])) by (node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "irqs",
+                  "refId": "F",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(rate(node_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",mode=\"iowait\"}[$__rate_interval])) by (node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "iowait",
+                  "refId": "C",
+                  "step": 2
+                },
+                {
+                  "expr": "1 - sum(rate(node_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",mode=\"idle\"}[$__rate_interval])) by (node) - sum(rate(node_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",mode=\"system\"}[$__rate_interval])) by (node) - sum(rate(node_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",mode=\"user\"}[$__rate_interval])) by (node) unless sum(rate(node_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",mode=\"nice\"}[$__rate_interval])) by (node)",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "other",
+                  "refId": "A",
+                  "step": 1
+                },
+                {
+                  "expr": "sum(rate(node_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",mode=\"idle\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total Idle",
+                  "refId": "J",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "CPU Usage on node (100% = 1 core)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 6,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",groupname=\"dmcproxy\", mode=\"user\"}[$aggregation])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "CPU User",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",groupname=\"dmcproxy\", mode=\"system\"}[$aggregation])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "CPU System",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DMC Proxy CPU Usage on node",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 7,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "namedprocess_namegroup_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",groupname=\"dmcproxy\", memtype=\"resident\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Resident memory",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "namedprocess_namegroup_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",groupname=\"dmcproxy\", memtype=\"virtual\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Virtual memory",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "namedprocess_namegroup_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",groupname=\"dmcproxy\", memtype=\"swapped\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Swapped memory",
+                  "refId": "C",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DMC Proxy Mem Usage on node",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 8,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (threadname) (rate(namedprocess_namegroup_thread_cpu_seconds_total{namespace=\"$namespace\", cluster=\"$cluster\",groupname=\"dmcproxy\",node=\"$node\",threadname=~\"worker-.*\", exporter=\"process\"}[$aggregation])) ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{label_name}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "DMC Proxy Workers Thread CPU Utilization",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 9,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "namedprocess_namegroup_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",groupname=\"ccs-redis\", memtype=\"resident\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Resident memory",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "namedprocess_namegroup_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",groupname=\"ccs-redis\", memtype=\"virtual\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Virtual memory",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "namedprocess_namegroup_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\",groupname=\"ccs-redis\", memtype=\"swapped\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Swapped memory",
+                  "refId": "C",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Redis-CCS Memory Usage ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 10,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\", mode=\"user\", groupname=~\"ccs-redis\"}[60s])*100) by (groupname)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{groupname}} user",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\", mode=\"system\", groupname=~\"ccs-redis\"}[60s])*100) by (groupname)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{groupname}} system",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Redis-CCS CPU Utilization",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "CPU",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 11,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(node_network_receive_bytes_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$__rate_interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Ingress for device: {{device}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "- rate(node_network_transmit_bytes_total{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$__rate_interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Egress for device: {{device}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Ingress/Egress Traffic",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 12,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "- topk(5, rate(endpoint_egress{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Egress listener proxy:{{proxy}} for database :{{db}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "topk(5, rate(endpoint_ingress{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Ingress listener proxy:{{proxy}} for database :{{db}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Top 5 Proxy Egress/Ingress",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 13,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg(rate(endpoint_write_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$__rate_interval]) + rate(endpoint_read_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$__rate_interval]) + rate(endpoint_other_requests_latency_histogram_sum{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$__rate_interval])) by (proxy, node) / avg(rate(endpoint_write_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$__rate_interval]) + rate(endpoint_read_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$__rate_interval]) + rate(endpoint_other_requests_latency_histogram_count{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$__rate_interval])) by (proxy, node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "listener: {{proxy}}  database: {{db}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Avg Proxy Latency",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 14,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "topk(10,endpoint_client_connections{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"} - endpoint_client_disconnections{namespace=\"$namespace\", cluster=\"$cluster\",node=\"$node\"} - endpoint_proxy_disconnections{namespace=\"$namespace\", cluster=\"$cluster\",node=\"$node\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "active client connections - database:{{db}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Top 10 Active Endpoint Connections",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 15,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "topk(10, sum(rate(endpoint_read_requests{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$__rate_interval]) + rate(endpoint_write_requests{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$__rate_interval]) + rate(endpoint_other_requests{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}[$__rate_interval])) by (db, proxy))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "listener: {{proxy}} for database: {{db}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Top 10 Active Proxy By Requests (read/write/other)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ops",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Traffic",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 16,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "topk(10, redis_server_used_ram{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"} or redis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}, database:{{db}},  role:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Top 10 Shards By Used Ram ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 17,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\", mode=\"user\", groupname=~\".*redis-.*\"}[60s])*100) by (groupname)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard: {{groupname}} user",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(rate(namedprocess_namegroup_cpu_seconds_total{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\", mode=\"system\", groupname=~\".*redis-.*\"}[60s])*100) by (groupname)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard: {{groupname}} system",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "CPU Usage Per Shard",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 18,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}, database:{{db}},  role:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Shards Size (Sort By Size)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Shards Utlization",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 19,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(redis_server_used_memory{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "total shards memory",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(redis_server_used_ram{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "total shards ram",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total Shards Memory Usage",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 20,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "node_available_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\",node=\"$node\"} or node_available_memory_no_overbooking_bytes{namespace=\"$namespace\", cluster=\"$cluster\",node=\"$node\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Available memory",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Available Memory ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 21,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_rdb_last_cow_size{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"} unless delta(redis_server_rdb_last_cow_size{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"}[$__rate_interval]) == 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard last RDB cow - redis: {{redis}}",
+                  "refId": "A",
+                  "step": 2
+                },
+                {
+                  "expr": "redis_server_aof_last_cow_size{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"} unless delta(redis_server_aof_last_cow_size{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"}[$__rate_interval]) == 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard last AOF cow - redis: {{redis}}",
+                  "refId": "B",
+                  "step": 2
+                },
+                {
+                  "expr": "redis_server_mem_aof_buffer{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard aofrw buffers - redis: {{redis}}",
+                  "refId": "C",
+                  "step": 2
+                },
+                {
+                  "expr": "redis_server_mem_clients_slaves{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard salve buffers - redis: {{redis}}",
+                  "refId": "D",
+                  "step": 2
+                },
+                {
+                  "expr": "redis_server_rdb_bgsave_in_progress{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "rdb_bgsave_in_progress",
+                  "refId": "E",
+                  "step": 2
+                },
+                {
+                  "expr": "redis_server_aof_rewrite_in_progress{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "aof_rewrite_in_progress",
+                  "refId": "F",
+                  "step": 2
+                },
+                {
+                  "expr": "redis_server_current_cow_size{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Current CoW ",
+                  "refId": "G",
+                  "step": 2
+                },
+                {
+                  "expr": "redis_server_current_cow_peak{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Current CoW Peak",
+                  "refId": "H",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Fork Memory",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 22,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg(redis_server_allocator_active{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"} / redis_server_allocator_allocated{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"}) - 1",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "active / allocated (defraggable)",
+                  "refId": "A",
+                  "step": 2
+                },
+                {
+                  "expr": "avg(redis_server_allocator_resident{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"} / redis_server_allocator_active{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"}) - 1",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "resident / active (purgable)",
+                  "refId": "B",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(redis_server_allocator_active{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"} - redis_server_allocator_allocated{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "active - allocated (defraggable)",
+                  "refId": "C",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(redis_server_allocator_resident{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"} - redis_server_allocator_active{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "resident - active (purgable)",
+                  "refId": "D",
+                  "step": 2
+                },
+                {
+                  "expr": "avg(redis_server_active_defrag_running{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"})/100",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "active defrag running",
+                  "refId": "E",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(namedprocess_namegroup_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\", memtype=\"resident\", groupname=\"redis-${redis}\"}) - sum(redis_server_allocator_resident{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "process rss - allocator rss",
+                  "refId": "F",
+                  "step": 2
+                },
+                {
+                  "expr": "sum(namedprocess_namegroup_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\", memtype=\"resident\", groupname=\"redis-${redis}\"}) / sum(redis_server_allocator_resident{namespace=\"$namespace\", node=\"$node\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "process rss / allocator rss",
+                  "refId": "G",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Fragmentation",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 23,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_rdb_bgsave_in_progress{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"} !=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "BGSAVE {{redis}} database{{db}}",
+                  "refId": "A",
+                  "step": 2
+                },
+                {
+                  "expr": "redis_server_aof_rewrite_in_progress{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "AOFRW {{redis}} database {{db}}",
+                  "refId": "B",
+                  "step": 2
+                },
+                {
+                  "expr": "redis_server_module_fork_in_progress{namespace=\"$namespace\", cluster=\"$cluster\", node=\"$node\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Module fork {{redis}} database {{db}}",
+                  "refId": "C",
+                  "step": 2
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Forks",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Memory",
+          "titleSize": "h6"
+        }
+      ],
+      "schemaVersion": 14,
+      "style": "light",
+      "tags": [
+        "redis-enterprise",
+        "openshift-observe",
+        "ops"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(redis_server_up, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\"}, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "node",
+            "options": [],
+            "query": "label_values(node_config{namespace=\"$namespace\", cluster=\"$cluster\"}, node)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "1m",
+            "current": {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "aggregation",
+            "options": [],
+            "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "utc",
+      "title": "Redis Enterprise / Ops / Node Dashboard",
+      "uid": "re-observe-ops-node",
+      "version": 1
+    }

--- a/openshift/native-observe/dashboards/redis-enterprise-ops-redisearch-qps.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-ops-redisearch-qps.yaml
@@ -1,0 +1,2896 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-enterprise-ops-redisearch-qps
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+data:
+  redis-enterprise-ops-redisearch-qps.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "links": [],
+      "refresh": "30s",
+      "rows": [
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 1,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 4,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "redis_server_search_number_of_indexes{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Number of indexes",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 2,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "max(redis_server_search_fields_text_Text{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "TEXT",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_search_fields_tag_Tag{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "TAG",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_search_fields_numeric_Numeric{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "NUMERIC",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_search_fields_geo_Geo{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "GEO",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_search_fields_geoshape_Geoshape{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "GEOSHAPE",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_search_fields_vector_Vector{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "VECTOR",
+                  "refId": "F",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Fields count",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "General",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 3,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_search_number_of_active_indexes{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Active indexes",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 4,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_search_number_of_active_indexes_running_queries{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Active indexes running queries",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 5,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_search_number_of_active_indexes_indexing{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Active indexes indexing",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Current state",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 6,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(sum by(db) (redis_server_search_used_memory_indexes{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})) / (1024 * 1024)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_search_used_memory_indexes{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} / (1024 * 1024)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total Indexes memory",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 7,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_search_largest_memory_index{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} / (1024 * 1024)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Max memory index",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 8,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(redis_server_search_used_memory_indexes{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} / redis_server_search_number_of_indexes{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) / (1024 * 1024)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Average memory per index",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Memory",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 9,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_search_total_indexing_time{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total indexing time",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ms",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 10,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(redis_server_search_total_indexing_time{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Indexing time rate",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ms",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Indexing performance",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 11,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by(db) (redis_server_search_total_active_queries{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "(redis_server_search_total_active_queries{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Active queries",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 12,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(sum by(db) (rate(redis_server_search_total_query_execution_time_ms{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])) / sum by(db) (rate(redis_server_search_total_queries_processed{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "Query Server Latency",
+                  "step": 10
+                },
+                {
+                  "expr": "((rate(redis_server_search_total_query_execution_time_ms{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])) / (rate(redis_server_search_total_queries_processed{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Processed queries server latency",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ms",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 13,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(sum by(db) (rate(redis_server_search_total_query_execution_time_ms{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])) / sum by(db) (rate(redis_server_search_total_query_commands{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "Query Commands Server Latency",
+                  "step": 10
+                },
+                {
+                  "expr": "((rate(redis_server_search_total_query_execution_time_ms{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])) /(rate(redis_server_search_total_query_commands{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Query commands server latency",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ms",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 14,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by(db) (rate(redis_server_search_total_queries_processed{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "Queries per Second",
+                  "step": 10
+                },
+                {
+                  "expr": "(rate(redis_server_search_total_queries_processed{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "Query Commands per Second",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "QPS (processed queries)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 15,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by(db) (rate(redis_server_search_total_query_commands{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "(rate(redis_server_search_total_query_commands{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "QPS (query commands)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Queries",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 16,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by(db) (redis_server_search_global_total{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_search_global_total{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by(db) (redis_server_search_global_total_user{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} + redis_server_search_global_total_internal{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_search_global_total_user{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} + redis_server_search_global_total_internal{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "D",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total cursors",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 17,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by(db) (redis_server_search_global_total{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_search_global_idle{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by(db) (redis_server_search_global_idle_user{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} + redis_server_search_global_idle_internal{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_search_global_idle_user{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} + redis_server_search_global_idle_internal{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "C",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Idle cursors",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Cursors",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 18,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_search_errors_indexing_failures{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by(db) (redis_server_search_errors_indexing_failures{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Indexing failures",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 19,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_search_errors_for_index_with_max_failures{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Max indexing failures",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 20,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by(db) (redis_server_search_fields_text_IndexErrors{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "TEXT",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by(db) (redis_server_search_fields_tag_IndexErrors{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "TAG",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by(db) (redis_server_search_fields_numeric_IndexErrors{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "NUMERIC",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by(db) (redis_server_search_fields_geo_IndexErrors{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "GEO",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by(db) (redis_server_search_fields_geoshape_IndexErrors{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "GEOSHAPE",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by(db) (redis_server_search_fields_vector_IndexErrors{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "VECTOR",
+                  "refId": "F",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Per field Indexing failures",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Errors",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 21,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(sum by(db) (redis_server_search_bytes_collected{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}))/ (1024*1024)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_search_bytes_collected{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} / (1024*1024)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "(sum by(db) (redis_server_search_gc_bytes_collected{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}))/ (1024*1024)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_search_gc_bytes_collected{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"} / (1024*1024)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "D",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total memory collected",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 22,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(redis_server_search_bytes_collected{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) / rate(redis_server_search_total_cycles{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_search_gc_bytes_collected{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) / rate(redis_server_search_gc_total_cycles{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Average memory collected / cycle ",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 23,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(redis_server_search_total_ms_run{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) / rate(redis_server_search_total_cycles{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_search_gc_total_ms_run{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval]) / rate(redis_server_search_gc_total_cycles{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}[$__rate_interval])\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Average gc cycle duration",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ms",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 24,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by(db) (redis_server_search_total_docs_not_collected_by_gc{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_search_total_docs_not_collected_by_gc{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by(db) (redis_server_search_gc_total_docs_not_collected{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_search_gc_total_docs_not_collected{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "D",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total marked deleted docs",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 25,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by(db) (redis_server_search_marked_deleted_vectors{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_search_marked_deleted_vectors{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum by(db) (redis_server_search_gc_marked_deleted_vectors{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "db:{{db}}",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_search_gc_marked_deleted_vectors{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "redis:{{redis}}:{{role}}",
+                  "refId": "D",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total marked deleted vectors",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Garbage collector",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 26,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "max(redis_server_search_fields_text_Sortable{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "TEXT",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_search_fields_tag_Sortable{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "TAG",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_search_fields_numeric_Sortable{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "NUMERIC",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_search_fields_geo_Sortable{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "GEO",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_search_fields_geoshape_Sortable{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "GEOSHAPE",
+                  "refId": "E",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Sortable fields count",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 27,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "max(redis_server_search_fields_text_NoIndex{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "TEXT",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_search_fields_tag_NoIndex{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "TAG",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_search_fields_numeric_NoIndex{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "NUMERIC",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_search_fields_geo_NoIndex{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "GEO",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_search_fields_geoshape_NoIndex{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "GEOSHAPE",
+                  "refId": "E",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "NoIndex fields count",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 28,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "max(redis_server_search_fields_vector_HNSW{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "HNSW",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_search_fields_vector_Flat{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "FLAT",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Vector indexes count",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 29,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "max(redis_server_search_fields_tag_NoIndex{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}) or vector(0)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "TAG",
+                  "refId": "C",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Case sensitive fields count",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Fields Statistics",
+          "titleSize": "h6"
+        }
+      ],
+      "schemaVersion": 14,
+      "style": "light",
+      "tags": [
+        "redis-enterprise",
+        "openshift-observe",
+        "ops"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(redis_server_up, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\"}, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "db",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", cluster=\"$cluster\"}, db)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "1m",
+            "current": {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "aggregation",
+            "options": [],
+            "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "utc",
+      "title": "Redis Enterprise / Ops / RediSearch QPS dashboard",
+      "uid": "re-observe-ops-redisearch-qps",
+      "version": 1
+    }

--- a/openshift/native-observe/dashboards/redis-enterprise-ops-shard.yaml
+++ b/openshift/native-observe/dashboards/redis-enterprise-ops-shard.yaml
@@ -1,0 +1,1924 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-enterprise-ops-shard
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+data:
+  redis-enterprise-ops-shard.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "links": [],
+      "refresh": "30s",
+      "rows": [
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "bytes",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 1,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 4,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "scalar(redis_server_used_memory{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "Used Memory",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 2,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum by (db) (redis_server_db_keys{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "#Keys",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": null,
+              "decimals": null,
+              "format": "short",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 3,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "span": 3,
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "scalar(redis_server_connected_clients{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "A",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "",
+              "title": "#Connections",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Overview",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 4,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_used_memory{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "used_mem - role:{{role}}, node:{{node}}, slots:{{slots}}",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_used_ram{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "used_ram - role:{{role}}, node:{{node}}, slots:{{slots}}",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_max_ram{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} < redis_server_used_ram{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} *.5",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "max_ram (when low, near used_ram)",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_max_process_mem{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} < redis_server_max_ram{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} * 1.5",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "max_process_mem (when low, near max_ram)",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_used_ram{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} - redis_server_mem_aof_buffer{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"}  - redis_server_mem_clients_slaves{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "used ram - slave/aof bufs",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_used_memory{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} - redis_server_mem_aof_buffer{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\", redis=\"$redis\"} - redis_server_mem_clients_slaves{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "used memory - slave/aof bufs",
+                  "refId": "J",
+                  "step": 10
+                },
+                {
+                  "expr": "namedprocess_namegroup_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\", groupname=\"redis-${redis}\", memtype=\"resident\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Process RSS",
+                  "refId": "G",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_maxmemory{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} < redis_server_used_memory{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} * 1.5 and redis_server_maxmemory{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "maxmemory (when low, near maxmemory)",
+                  "refId": "H",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_max_process_mem{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} < redis_server_used_memory{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} * 1.5",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "max_process_mem (when low. near maxmemory)",
+                  "refId": "I",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_current_cow_size{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Child CoW",
+                  "refId": "F",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Used Memory",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 5,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(redis_server_total_commands_processed{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "commands / s",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_keyspace_read_hits{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "read hits /s",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_keyspace_read_misses{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "read misses /s",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_keyspace_write_hits{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "write hits /s",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_keyspace_write_misses{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "write misses / s",
+                  "refId": "E",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Ops Per Second",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 6,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(redis_server_total_net_input_bytes{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "ingress",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "- (rate(redis_server_total_net_output_bytes{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m]) - rate(redis_server_master_repl_offset{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "egress",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_master_repl_offset{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "replication (offset)",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_repl_touch_bytes{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "repl touch",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_total_net_input_bytes{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "repl input",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_repl_touch_bytes{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "repl output",
+                  "refId": "F",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Bandwidth",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Memory",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 7,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_db_keys{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "keys",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_db_expires{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "volatile",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_bigdb_ram{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}) by (redis,db,cluster)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "ram",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_bigdb_disk{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}) by (redis,db,cluster)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "disk",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(((max(redis_server_bigdb_ram{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}) by (redis,db,cluster)) + (max(redis_server_bigdb_disk{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} or redis_server_bigdb_disk{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}) by (redis,db,cluster)))) - sum(redis_server_db_keys{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "overlapping",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "max(redis_server_bigdb_clean{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}) by (redis,db,cluster)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "clean",
+                  "refId": "F",
+                  "step": 10
+                },
+                {
+                  "expr": "max( redis_server_bigdb_dirty{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}) by (redis,db,cluster)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "dirty",
+                  "refId": "G",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_total_blocking_keys{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "total_blocking_keys",
+                  "refId": "H",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_total_blocking_keys_on_nokey{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "total_blocking_keys_on_nokey",
+                  "refId": "I",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_tracking_total_keys{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "tracking_total_keys",
+                  "refId": "J",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_tracking_total_prefixes{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "total_blocking_keys",
+                  "refId": "L",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_pubsub_patterns{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "pubsub_patterns",
+                  "refId": "K",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_pubsub_channels{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "pubsub_channels",
+                  "refId": "M",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_pubsubshard_channels{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "pubsubshard_channels",
+                  "refId": "N",
+                  "step": 10
+                },
+                {
+                  "expr": "max( redis_server_bigdb_meta{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}) by (redis,db,cluster)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "meta",
+                  "refId": "O",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_total_watched_keys{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "total_watched_keys",
+                  "refId": "P",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_db_subexpiry{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "subexpiry",
+                  "refId": "Q",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "#Keys",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 8,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(redis_server_expired_keys{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard:$redis - expired",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_evicted_keys{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard:$redis - evicted",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_expired_subkeys{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard:$redis - expired_subkeys",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_big_disk_expired_subkeys_loaded{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard:$redis - big_disk_expired_subkeys_loaded",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_big_disk_expired_keys{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard:$redis - big_disk_expired_keys",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_big_disk_evicted_keys{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard:$redis - big_disk_evicted_keys",
+                  "refId": "F",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_big_ttl_histogram_expired{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard:$redis - big_ttl_histogram_expired",
+                  "refId": "G",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_keys_trimmed{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard:$redis - trimmed",
+                  "refId": "I",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_db0_avg_ttl{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard:$redis - avg_ttl",
+                  "refId": "J",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Expired / Evicted Objects Per Second",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 9,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 4,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_connected_clients{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Total",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_maxclients{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} < redis_server_connected_clients{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"} * 1.5",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "max-clients (when low)",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "delta(redis_server_total_connections_received{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "conections / minute",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_blocked_clients{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "blocked_clients",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_tracking_clients{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "tracking_clients",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_pubsub_clients{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "pubsub_clients",
+                  "refId": "F",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_watching_clients{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "watching_clients",
+                  "refId": "G",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Shard Connections",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Keyspace",
+          "titleSize": "h6"
+        },
+        {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 10,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(redis_server_keyspace_read_hits{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"}[60s])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "read hits",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_keyspace_write_hits{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"}[60s])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "write hits",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_keyspace_read_misses{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"}[60s])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "read misses",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_keyspace_write_misses{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"}[60s])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "write misses",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_lazyfreed_objects{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"}[60s])!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "lazyfreed objects",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_total_error_replies{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"}[60s])!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "total error replies",
+                  "refId": "F",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_prefetch_expired{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"}[60s])!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "prefetch_expired",
+                  "refId": "G",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(redis_server_prefetch_missing{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"}[60s])!=0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "prefetch_missing",
+                  "refId": "H",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Read/Write Hits/Misses + Lazyfree + Errors",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ops",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 11,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_allocator_active{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "active",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": " redis_server_allocator_allocated{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "allocated",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_allocator_resident{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "resident",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "namedprocess_namegroup_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\", groupname=\"redis-${redis}\", memtype=\"resident\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "process RSS",
+                  "refId": "D",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Ram Allocator Usage",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 12,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(redis_server_ram_overhead{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"} - redis_server_mem_clients_slaves{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"} )/ redis_server_max_ram{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "% ram overhead",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_ram_overhead{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"} ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "total overhead",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_mem_clients_slaves{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"} ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "slave buffers",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_mem_clients_normal{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"} ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "client buffers",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_mem_aof_buffer{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"} > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "aof buffer",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_mem_replication_backlog{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"} ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "replication backlog",
+                  "refId": "F",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_ram_keys_size{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"} > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "ram_keys_size",
+                  "refId": "G",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_keys_ram_overhead{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"} > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "dictionaries",
+                  "refId": "H",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_used_memory_scripts{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"} > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "scripts",
+                  "refId": "I",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_rocks_ram_used_total{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"} > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "rocks_ram_used_total",
+                  "refId": "J",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_rocks_ram_used_for_mem_tables{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"} > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "rocks_ram_used_for_mem_tables",
+                  "refId": "K",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_used_memory_vm_total{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"} > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Lua VM",
+                  "refId": "L",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_mem_overhead_db_hashtable_rehashing{namespace=\"$namespace\", cluster=\"$cluster\",db=\"$db\", redis=\"$redis\"} > 0",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "dictionary rehashing",
+                  "refId": "M",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Shard Ram Overheads",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": null,
+              "fill": 1,
+              "id": 13,
+              "interval": "1m",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 6,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "redis_server_mem_fragmentation_ratio{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "shard rss fragmentation (total)",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_allocator_active{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"} / redis_server_allocator_allocated{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Shard allocator fragmentation (defraggable?)",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "redis_server_allocator_resident{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"} / redis_server_allocator_active{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "allocator RSS / active (purgable?)",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(namedprocess_namegroup_memory_bytes{namespace=\"$namespace\", cluster=\"$cluster\", groupname=\"redis-${redis}\", memtype=\"resident\"}) / sum(redis_server_allocator_resident{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\",cluster=\"$cluster\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "process RSS / allocator resident (process overheads)",
+                  "refId": "D",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Fragmentation",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Memory breakdown",
+          "titleSize": "h6"
+        }
+      ],
+      "schemaVersion": 14,
+      "style": "light",
+      "tags": [
+        "redis-enterprise",
+        "openshift-observe",
+        "ops"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(redis_server_up, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\"}, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "db",
+            "options": [],
+            "query": "label_values(db_status{namespace=\"$namespace\", cluster=\"$cluster\"}, db)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "redis",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", cluster=\"$cluster\", db=\"$db\"}, redis)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "node",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"},node)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "role",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"},role)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "slots",
+            "options": [],
+            "query": "label_values(redis_server_up{namespace=\"$namespace\", db=\"$db\", redis=\"$redis\", cluster=\"$cluster\"}, slots)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "1m",
+            "current": {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "aggregation",
+            "options": [],
+            "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "status",
+            "options": [],
+            "query": "label_values(db_status{namespace=\"$namespace\", db=\"$db\", cluster=\"$cluster\"}, status)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "utc",
+      "title": "Redis Enterprise / Ops / Shard dashboard",
+      "uid": "re-observe-ops-shard",
+      "version": 1
+    }

--- a/openshift/native-observe/kustomization.yaml
+++ b/openshift/native-observe/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - redis-enterprise-servicemonitor.yaml
+  - redis-enterprise-prometheusrule.yaml
+  - dashboards/redis-enterprise-basic-cluster-status.yaml
+  - dashboards/redis-enterprise-basic-database-status.yaml
+  - dashboards/redis-enterprise-basic-node.yaml
+  - dashboards/redis-enterprise-basic-shard.yaml
+  - dashboards/redis-enterprise-basic-active-active.yaml
+  - dashboards/redis-enterprise-basic-synchronization.yaml
+  - dashboards/redis-enterprise-ops-cluster.yaml
+  - dashboards/redis-enterprise-ops-database.yaml
+  - dashboards/redis-enterprise-ops-node.yaml
+  - dashboards/redis-enterprise-ops-shard.yaml
+  - dashboards/redis-enterprise-ops-latency.yaml
+  - dashboards/redis-enterprise-ops-active-active-lag.yaml
+  - dashboards/redis-enterprise-ops-redisearch-qps.yaml

--- a/openshift/native-observe/redis-enterprise-prometheusrule.yaml
+++ b/openshift/native-observe/redis-enterprise-prometheusrule.yaml
@@ -160,7 +160,7 @@ spec:
             description: Replication Latency {{$labels.cluster}} exceeded 500ms for 10 minutes
             runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#synchronization
         - alert: CRDTLag Status
-          expr: database_syncer_lag_ms{syncer_type="crdt", job="redis", cluster="localhost"} > 500
+          expr: database_syncer_lag_ms{syncer_type="crdt"} > 500
           for: 5m
           labels:
             severity: warning
@@ -211,7 +211,7 @@ spec:
             description: "Low on Memory - Cluster: {{$labels.cluster}} Memory Free: {{$value}}%"
             runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#memory
         - alert: Node CPU Usage
-          expr: rate(namedprocess_namegroup_cpu_seconds_total{job="redis", cluster="localhost", node="1"}[5m]) >= 0
+          expr: rate(namedprocess_namegroup_cpu_seconds_total[5m]) >= 0
           for: 5m
           labels:
             severity: critical
@@ -242,7 +242,7 @@ spec:
             description: "Slave has no master - Cluster: {{$labels.cluster}} Shard: {{$labels.redis}} Node: {{$labels.node}}"
             runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#cpu
         - alert: Shard CPU Usage
-          expr: rate(namedprocess_namegroup_cpu_seconds_total{job="redis", cluster="localhost", node="1", redis="1"}[5m]) >= 0
+          expr: rate(namedprocess_namegroup_cpu_seconds_total[5m]) >= 0
           for: 5m
           labels:
             severity: notification
@@ -252,7 +252,7 @@ spec:
             description: "Busy Shard - Cluster: {{$labels.cluster}} Shard: {{$labels.redis}} Node: {{$labels.node}} CPU: {{$value}}%"
             runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#cpu
         - alert: Hot Master Shard
-          expr: rate(namedprocess_namegroup_cpu_seconds_total{job="redis", cluster="localhost", role="master", node="1", redis="1"}[5m]) >= 0
+          expr: rate(namedprocess_namegroup_cpu_seconds_total{role="master"}[5m]) >= 0
           for: 1m
           labels:
             severity: critical
@@ -263,7 +263,7 @@ spec:
             description: "Hot Shard - Cluster: {{$labels.cluster}} Shard: {{$labels.redis}} Node: {{$labels.node}} CPU: {{$value}}%"
             runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#cpu
         - alert: Proxy CPU Usage
-          expr: rate(namedprocess_namegroup_cpu_seconds_total{job="redis", cluster="localhost", groupname="dmcproxy"}[5m]) > 0.0
+          expr: rate(namedprocess_namegroup_cpu_seconds_total{groupname="dmcproxy"}[5m]) > 0.0
           for: 5m
           labels:
             severity: critical

--- a/openshift/native-observe/redis-enterprise-prometheusrule.yaml
+++ b/openshift/native-observe/redis-enterprise-prometheusrule.yaml
@@ -211,7 +211,8 @@ spec:
             description: "Low on Memory - Cluster: {{$labels.cluster}} Memory Free: {{$value}}%"
             runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#memory
         - alert: Node CPU Usage
-          expr: rate(namedprocess_namegroup_cpu_seconds_total[5m]) >= 0
+          # Example threshold: alert when a Redis Enterprise process consumes more than 80% of a CPU core.
+          expr: (rate(namedprocess_namegroup_cpu_seconds_total[5m]) * 100) > 80
           for: 5m
           labels:
             severity: critical
@@ -242,7 +243,8 @@ spec:
             description: "Slave has no master - Cluster: {{$labels.cluster}} Shard: {{$labels.redis}} Node: {{$labels.node}}"
             runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#cpu
         - alert: Shard CPU Usage
-          expr: rate(namedprocess_namegroup_cpu_seconds_total[5m]) >= 0
+          # Example threshold: alert when a Redis shard process consumes more than 80% of a CPU core.
+          expr: (rate(namedprocess_namegroup_cpu_seconds_total[5m]) * 100) > 80
           for: 5m
           labels:
             severity: notification
@@ -252,7 +254,8 @@ spec:
             description: "Busy Shard - Cluster: {{$labels.cluster}} Shard: {{$labels.redis}} Node: {{$labels.node}} CPU: {{$value}}%"
             runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#cpu
         - alert: Hot Master Shard
-          expr: rate(namedprocess_namegroup_cpu_seconds_total{role="master"}[5m]) >= 0
+          # Example threshold: alert when a master shard consumes more than 80% of a CPU core.
+          expr: (rate(namedprocess_namegroup_cpu_seconds_total{role="master"}[5m]) * 100) > 80
           for: 1m
           labels:
             severity: critical

--- a/openshift/native-observe/redis-enterprise-prometheusrule.yaml
+++ b/openshift/native-observe/redis-enterprise-prometheusrule.yaml
@@ -1,0 +1,274 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: redis-enterprise-observe-alerts
+  namespace: redis-enterprise
+  labels:
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+    prometheus: user-workload
+spec:
+
+  #################################################        ALERTS        #################################################
+
+  ### DATABASE, eg. all begin with bdb_ ###
+  groups:
+    - name: latency
+      rules:
+        - alert: Average Latency Warning
+          # this will depend on your use case and what your expected actual latency will be - in this example we are alerting if the average latency is over 2ms
+          expr: '(sum by (db)(irate(endpoint_read_requests_latency_histogram_sum[1m]) + irate(endpoint_write_requests_latency_histogram_sum[1m]) + irate(endpoint_other_requests_latency_histogram_sum[1m])))/(sum by (db)(irate(endpoint_read_requests[1m]) + irate(endpoint_write_requests[1m]) + irate(endpoint_other_requests[1m])))/1000 > 2'
+          for: 30s
+          labels:
+            severity: notification
+            type: latency
+          annotations:
+            summary: Average Latency Warning
+            description: "High Latency - DB: {{$labels.db}} Latency: {{$value}} ms"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#read-latency
+        - alert: Average Latency Critical
+          expr: '(sum by (db)(irate(endpoint_read_requests_latency_histogram_sum[1m]) + irate(endpoint_write_requests_latency_histogram_sum[1m]) + irate(endpoint_other_requests_latency_histogram_sum[1m])))/(sum by (db)(irate(endpoint_read_requests[1m]) + irate(endpoint_write_requests[1m]) + irate(endpoint_other_requests[1m])))/1000 > 5'
+          for: 30s
+          labels:
+            severity: notification
+            type: latency
+          annotations:
+            summary: Average Latency Warning
+            description: "High Latency - DB: {{$labels.db}} Latency: {{$value}} ms"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#read-latency
+    - name: connections
+      rules:
+        - alert: No Redis Connections
+          expr: endpoint_client_connections < 1
+          for: 30s
+          labels:
+            severity: notification
+            job: redis
+            type: connection
+          annotations:
+            summary: "No Redis Connections"
+            description: "No Connections - Cluster: {{$labels.cluster}} DB: {{$labels.db}} Connections: {{$value}}"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#connections
+        - alert: Excessive Connections
+          expr: endpoint_client_connections - endpoint_client_disconnections > 64000
+          for: 30s
+          labels:
+            severity: critical
+            job: redis
+            type: connection
+          annotations:
+            summary: "Too many connections"
+            description: "Too Many Connections - Cluster: {{$labels.cluster}} DB: {{$labels.db}} Connections: {{$value}}"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#connections
+    - name: throughput
+      rules:
+        - alert: No Redis Requests
+          expr: increase(endpoint_read_requests[1m]) < 1 and increase(endpoint_write_requests[1m]) < 1
+          for: 30s
+          labels:
+            severity: critical
+            type: throughput
+          annotations:
+            summary: No Redis Requests
+            description: "Too few Redis operations - Cluster: {{$labels.cluster}} DB: {{$labels.db}}  {{$value}} (ops/sec)"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#connections
+        - alert: Excessive Redis Requests
+          expr: (irate(endpoint_read_requests[1m]) + irate(endpoint_write_requests[1m]))/2 > 100000 # The actual threshold will be based on your Redis Database, adjust as needed
+          for: 30s
+          labels:
+            severity: critical
+            type: throughput
+          annotations:
+            summary: Excessive Redis Requests
+            description: "Too Many Redis Operations - Cluster: {{$labels.cluster}} DB: {{$labels.db}} {{$value}} (ops/sec)"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#connections
+    - name: capacity
+      rules:
+        - alert: DB full
+          expr: ((redis_server_used_memory/redis_server_maxmemory) * 100 ) > 95
+          for: 30s
+          labels:
+            severity: critical
+            type: capacity
+          annotations:
+            summary: DB is full
+            description: "DB Usage - Cluster: {{$labels.cluster}} DB: {{$labels.db}} Usage: {{$value}}% full"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#memory
+        - alert: DB full in 2 hours
+          expr: round((redis_server_used_memory/redis_server_maxmemory) * 100) < 95 and (predict_linear(redis_server_used_memory[15m], 2 * 3600) / redis_server_maxmemory) > 0.3 and round(predict_linear(redis_server_used_memory[15m], 2 * 3600)/redis_server_maxmemory) > 0.95
+          for: 30s
+          labels:
+            severity: notification
+            type: capacity
+          annotations:
+            summary: DB will be full in two hours
+            description: "DB Usage - Cluster: {{$labels.cluster}} DB: {{$labels.db}} Usage: {{$value}}% in 2 hours"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#memory
+    - name: utilization
+      rules:
+        - alert: Low Hit Ratio
+          expr: (irate(redis_server_keyspace_read_hits{role="master"}[1m])/irate(redis_server_keyspace_read_misses{role="master"}[1m])) < 1
+          for: 30s
+          labels:
+            severity: notification
+            type: utilization
+          annotations:
+            summary: Low Hit Ratio
+            description: "Low Hit Ratio: {{$labels.cluster}} DB: {{$labels.db}} Hit Ratio: {{$value}}%"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#cache-hit-ratio-and-eviction
+        - alert: Unexpected Object Eviction
+          expr: redis_server_evicted_keys{role="master"} > 1
+          for: 3m
+          labels:
+            job: redis
+            severity: critical
+            type: utilization
+          annotations:
+            summary: Unexpected Object Eviction
+            description: "Evictions Occurring: {{$labels.cluster}} DB: {{$labels.db}} EvictionsPerSecond: {{$value}}"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#cache-hit-ratio-and-eviction
+    - name: synchronization
+      rules:
+        - alert: ReplicaSync Status
+          expr: database_syncer_current_status{syncer_type="replicaof"} > 0
+          for: 5m
+          labels:
+            severity: warning
+            type: synchronization
+          annotations:
+            summary: Replication - Resynchronization Requests (Status)
+            description: Replication on {{$labels.cluster}} not synchronized in 10 minutes
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#synchronization
+        - alert: CRDTSync Status
+          expr: database_syncer_current_status{syncer_type="crdt"} > 0
+          for: 5m
+          labels:
+            severity: warning
+            type: synchronization
+          annotations:
+            summary: Replication - Unsynchronized (CRDT)
+            description: CRDT Replication on {{$labels.cluster}} not synchronized for 5 minutes
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#synchronization
+        - alert: ReplicaLag Status
+          expr: database_syncer_lag_ms{syncer_type="replicaof"} > 500
+          for: 5m
+          labels:
+            severity: warning
+            type: synchronization
+          annotations:
+            summary: Replication - High Latency (Status)
+            description: Replication Latency {{$labels.cluster}} exceeded 500ms for 10 minutes
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#synchronization
+        - alert: CRDTLag Status
+          expr: database_syncer_lag_ms{syncer_type="crdt", job="redis", cluster="localhost"} > 500
+          for: 5m
+          labels:
+            severity: warning
+            type: synchronization
+          annotations:
+            summary: Replication - High Latency (CRDT)
+            description: CRDT Replication Latency on {{$labels.cluster}} exceeded 500ms for 10 minutes
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#synchronization
+    - name: nodes
+      rules:
+        - alert: Node Not Responding
+          expr: count(node_metrics_up) != 3 # will depend on the number of nodes in your Redis cluster
+          for: 5m
+          labels:
+            severity: critical
+            job: redis
+            type: node
+          annotations:
+            summary: Node Not Responding
+            description: "Node Down - Cluster: {{$labels.cluster}} Expected Nodes: 3 Actual: {{$value}}"
+        - alert: Node Persistent Storage
+          expr: round((node_persistent_storage_free_bytes/node_persistent_storage_avail_bytes) * 100) <= 5
+          for: 2m
+          labels:
+            severity: critical
+            job: redis
+            type: node
+          annotations:
+            summary: Node Persistent Storage
+            description: "Low on Persistent Storage - Cluster: {{$labels.cluster}} Space Free: {{$value}}%"
+        - alert: Node Ephemeral Storage
+          expr: node_ephemeral_storage_free_bytes < 5000000000 # Depends on your environment how much ephemeral storage you want to trigger on (5GB in this example)
+          for: 2m
+          labels:
+            severity: critical
+            type: node
+          annotations:
+            summary: Node Ephemeral Storage
+            description: "Low on Ephemeral Storage - Cluster: {{$labels.cluster}} Space Free: {{$value}}%"
+        - alert: Node Free Memory
+          expr: node_available_memory_bytes < 5000000000 # Depends on your environment how much memory you want to trigger on (5GB in this example)
+          for: 2m
+          labels:
+            severity: critical
+            type: node
+          annotations:
+            summary: Node Free Memory
+            description: "Low on Memory - Cluster: {{$labels.cluster}} Memory Free: {{$value}}%"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#memory
+        - alert: Node CPU Usage
+          expr: rate(namedprocess_namegroup_cpu_seconds_total{job="redis", cluster="localhost", node="1"}[5m]) >= 0
+          for: 5m
+          labels:
+            severity: critical
+            type: node
+          annotations:
+            summary: Node CPU Usage
+            description: "High CPU Usage - Cluster: {{$labels.cluster}} Usage: {{$value}}%"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#cpu
+    - name: shards
+      rules:
+        - alert: Shard Down
+          expr: redis_server_up == 0
+          for: 1m
+          labels:
+            severity: page
+            type: shard
+          annotations:
+            summary: Redis Shard instance is down
+            description: Redis Shard instance {{$labels.cluster}} is down
+        - alert: Master Shard Down
+          expr: floor(redis_server_master_link_status{role="slave"}) < 1
+          for: 1m
+          labels:
+            severity: notification
+            type: shard
+          annotations:
+            summary: Master Shard Down
+            description: "Slave has no master - Cluster: {{$labels.cluster}} Shard: {{$labels.redis}} Node: {{$labels.node}}"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#cpu
+        - alert: Shard CPU Usage
+          expr: rate(namedprocess_namegroup_cpu_seconds_total{job="redis", cluster="localhost", node="1", redis="1"}[5m]) >= 0
+          for: 5m
+          labels:
+            severity: notification
+            type: shard
+          annotations:
+            summary: Shard CPU Usage
+            description: "Busy Shard - Cluster: {{$labels.cluster}} Shard: {{$labels.redis}} Node: {{$labels.node}} CPU: {{$value}}%"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#cpu
+        - alert: Hot Master Shard
+          expr: rate(namedprocess_namegroup_cpu_seconds_total{job="redis", cluster="localhost", role="master", node="1", redis="1"}[5m]) >= 0
+          for: 1m
+          labels:
+            severity: critical
+            type: shard
+            role: master
+          annotations:
+            summary: Hot Master Shard
+            description: "Hot Shard - Cluster: {{$labels.cluster}} Shard: {{$labels.redis}} Node: {{$labels.node}} CPU: {{$value}}%"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#cpu
+        - alert: Proxy CPU Usage
+          expr: rate(namedprocess_namegroup_cpu_seconds_total{job="redis", cluster="localhost", groupname="dmcproxy"}[5m]) > 0.0
+          for: 5m
+          labels:
+            severity: critical
+            type: proxy
+          annotations:
+            summary: Proxy CPU Usage
+            description: "Proxy CPU usage has exceeded {{$value}}% for more than 60 seconds"
+            runbook: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/observability/#cpu

--- a/openshift/native-observe/redis-enterprise-servicemonitor.yaml
+++ b/openshift/native-observe/redis-enterprise-servicemonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: redis-enterprise-observe
+  namespace: redis-enterprise
+  labels:
+    app.kubernetes.io/name: redis-enterprise-observe
+    app.kubernetes.io/part-of: redis-enterprise-observability
+spec:
+  selector:
+    matchLabels:
+      redis.io/service: prom-metrics
+  endpoints:
+    - port: prometheus
+      scheme: https
+      path: /v2
+      interval: 30s
+      scrapeTimeout: 30s
+      tlsConfig:
+        insecureSkipVerify: true


### PR DESCRIPTION
## Summary
- Add native OpenShift Observe dashboard manifests for Redis Enterprise using legacy dashboard ConfigMaps.
- Add ServiceMonitor and PrometheusRule manifests for in-cluster Redis Enterprise metrics and alerts.
- Add customer-facing deployment docs and a runbook for an OpenShift cluster where Redis Enterprise is already installed and working.

## Dashboard Scope
- Basic dashboards: Cluster Status, Database Status, Node, Shard, Active-Active, Synchronization.
- Ops dashboards: Cluster, Database, Node, Shard, Latency, Active-Active Lag, RediSearch QPS.

## Live OpenShift Validation
Tested with the authenticated `oc` context against a cluster containing two active-active Redis Enterprise clusters in `ns-a` and `ns-b`.

- Enabled user workload monitoring with `enableUserWorkload: true`.
- Labeled Redis Enterprise metrics services in `ns-a` and `ns-b` with `redis.io/observe=metrics`.
- Applied ServiceMonitor and PrometheusRule resources in both Redis Enterprise namespaces.
- Applied all 13 dashboard ConfigMaps in `openshift-config-managed`.
- Verified Thanos returned Redis Enterprise data for both namespaces:
  - `count(redis_server_up{namespace="ns-a"}) == 4`
  - `count(redis_server_up{namespace="ns-b"}) == 4`
  - `sum(endpoint_client_connections{namespace="ns-a"}) == 14`
  - `sum(endpoint_client_connections{namespace="ns-b"}) == 14`
  - `count(node_metrics_up{namespace="ns-a"}) == 3`
  - `count(node_metrics_up{namespace="ns-b"}) == 3`
- Confirmed Thanos Ruler loaded the Redis Enterprise rule files. Existing Redis alert expression warnings about counter naming were informational and did not block rule loading.

## Static Checks
- `git diff --cached --check`
- Dashboard embedded JSON validation with `yq` and `jq`
- `oc kustomize openshift/native-observe`
- `npm run docs`

## Notes
- `promtool` was not installed locally, so rule validation was covered by OpenShift server-side deployment and Thanos Ruler loading.
- Unsupported Grafana-only panel features are intentionally omitted from the native OpenShift dashboards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds OpenShift `ServiceMonitor`/`PrometheusRule` and legacy dashboard `ConfigMap` manifests that, if applied, affect cluster monitoring/alerting behavior and scrape configuration. Changes are additive but touch operational observability resources in production clusters.
> 
> **Overview**
> Adds **OpenShift-native observability support** for Redis Enterprise via legacy Observe dashboard `ConfigMap` manifests (Basic and Ops dashboard sets) and a `kustomization.yaml` bundle to apply them together.
> 
> Introduces OpenShift user-workload monitoring integration manifests: a `ServiceMonitor` for scraping Redis Enterprise metrics over HTTPS (`/v2`, `insecureSkipVerify: true`) and a `PrometheusRule` exposing Redis Enterprise alert rules to OpenShift Observe.
> 
> Updates documentation to include an **OpenShift Native Observe Dashboards** install guide plus an OpenShift `native-observe` README and an active-active runbook, and links the new platform/guide from the top-level `README.md` and Antora nav.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7242457593569928036cdb3c40fe172eaa516623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->